### PR TITLE
feat: struct data passing (VertexProtocol + generics), with initial impl of TerrainShader, MUCH faster generation

### DIFF
--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -7,14 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		750379A0254A8538002A0C13 /* SimpleShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 7503798C254A8537002A0C13 /* SimpleShaders.metal */; };
+		750379A0254A8538002A0C13 /* GridShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 7503798C254A8537002A0C13 /* GridShaders.metal */; };
 		750379A1254A8538002A0C13 /* MapRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7503798D254A8537002A0C13 /* MapRenderer.swift */; };
-		750379A2254A8538002A0C13 /* SimpleShaderTypes.h in Resources */ = {isa = PBXBuildFile; fileRef = 7503798E254A8537002A0C13 /* SimpleShaderTypes.h */; };
+		750379A2254A8538002A0C13 /* SharedShaderTypes.h in Resources */ = {isa = PBXBuildFile; fileRef = 7503798E254A8537002A0C13 /* SharedShaderTypes.h */; };
 		750379A3254A8538002A0C13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7503798F254A8538002A0C13 /* Assets.xcassets */; };
 		757DF60C254F26EE005723D5 /* ChunkGenerationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF60B254F26EE005723D5 /* ChunkGenerationState.swift */; };
 		757DF61E254F687F005723D5 /* SwiftPriorityQueue in Frameworks */ = {isa = PBXBuildFile; productRef = 757DF61D254F687F005723D5 /* SwiftPriorityQueue */; };
 		757DF621254F90CB005723D5 /* GeneraDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF620254F90CB005723D5 /* GeneraDebugView.swift */; };
 		757DF626254FA0FF005723D5 /* DebugDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF625254FA0FF005723D5 /* DebugDelegate.swift */; };
+		757E14EA255151F50036AEB5 /* Util.metal in Sources */ = {isa = PBXBuildFile; fileRef = 757E14E9255151F50036AEB5 /* Util.metal */; };
 		759E000A254E16FC004CF89F /* VectoredDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759E0009254E16FC004CF89F /* VectoredDirection.swift */; };
 		759EFFFC254DE361004CF89F /* GeneraMTLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759EFFFB254DE361004CF89F /* GeneraMTLView.swift */; };
 		75B2B74C254B68FB00351DC8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 75B2B747254B68FB00351DC8 /* Main.storyboard */; };
@@ -40,14 +41,16 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		7503798C254A8537002A0C13 /* SimpleShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = SimpleShaders.metal; sourceTree = "<group>"; };
+		7503798C254A8537002A0C13 /* GridShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = GridShaders.metal; sourceTree = "<group>"; };
 		7503798D254A8537002A0C13 /* MapRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapRenderer.swift; sourceTree = "<group>"; };
-		7503798E254A8537002A0C13 /* SimpleShaderTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimpleShaderTypes.h; sourceTree = "<group>"; };
+		7503798E254A8537002A0C13 /* SharedShaderTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedShaderTypes.h; sourceTree = "<group>"; };
 		7503798F254A8538002A0C13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		75037994254A8538002A0C13 /* Genera.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Genera.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		757DF60B254F26EE005723D5 /* ChunkGenerationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkGenerationState.swift; sourceTree = "<group>"; };
 		757DF620254F90CB005723D5 /* GeneraDebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneraDebugView.swift; sourceTree = "<group>"; };
 		757DF625254FA0FF005723D5 /* DebugDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDelegate.swift; sourceTree = "<group>"; };
+		757E14E9255151F50036AEB5 /* Util.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Util.metal; sourceTree = "<group>"; };
+		757E14EC2551525D0036AEB5 /* Util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Util.h; sourceTree = "<group>"; };
 		759E0009254E16FC004CF89F /* VectoredDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectoredDirection.swift; sourceTree = "<group>"; };
 		759EFFFB254DE361004CF89F /* GeneraMTLView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneraMTLView.swift; sourceTree = "<group>"; };
 		75B2B745254B68FB00351DC8 /* GeneraMacOS.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = GeneraMacOS.entitlements; sourceTree = "<group>"; };
@@ -101,9 +104,11 @@
 		7503798B254A8537002A0C13 /* metal */ = {
 			isa = PBXGroup;
 			children = (
-				7503798C254A8537002A0C13 /* SimpleShaders.metal */,
+				757E14EC2551525D0036AEB5 /* Util.h */,
+				757E14E9255151F50036AEB5 /* Util.metal */,
+				7503798E254A8537002A0C13 /* SharedShaderTypes.h */,
+				7503798C254A8537002A0C13 /* GridShaders.metal */,
 				75C4B4B52550062600F36372 /* TerrainShaders.metal */,
-				7503798E254A8537002A0C13 /* SimpleShaderTypes.h */,
 			);
 			path = metal;
 			sourceTree = "<group>";
@@ -269,7 +274,7 @@
 			files = (
 				75B2B74C254B68FB00351DC8 /* Main.storyboard in Resources */,
 				750379A3254A8538002A0C13 /* Assets.xcassets in Resources */,
-				750379A2254A8538002A0C13 /* SimpleShaderTypes.h in Resources */,
+				750379A2254A8538002A0C13 /* SharedShaderTypes.h in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -296,7 +301,8 @@
 				75C4B4B62550062600F36372 /* TerrainShaders.metal in Sources */,
 				75FA6D31254BF07A00A1B409 /* MapUpdateDelegate.swift in Sources */,
 				757DF621254F90CB005723D5 /* GeneraDebugView.swift in Sources */,
-				750379A0254A8538002A0C13 /* SimpleShaders.metal in Sources */,
+				750379A0254A8538002A0C13 /* GridShaders.metal in Sources */,
+				757E14EA255151F50036AEB5 /* Util.metal in Sources */,
 				75B2B764254B71AD00351DC8 /* RandomTileGenerator.swift in Sources */,
 				75FA6D73254CEB0400A1B409 /* GeneratorProtocol.swift in Sources */,
 				75B2B74D254B68FB00351DC8 /* AppDelegate.swift in Sources */,
@@ -454,7 +460,7 @@
 				PRODUCT_NAME = Genera;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = metal/SimpleShaderTypes.h;
+				SWIFT_OBJC_BRIDGING_HEADER = metal/SharedShaderTypes.h;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -479,7 +485,7 @@
 				PRODUCT_NAME = Genera;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = metal/SimpleShaderTypes.h;
+				SWIFT_OBJC_BRIDGING_HEADER = metal/SharedShaderTypes.h;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -9,13 +9,14 @@
 /* Begin PBXBuildFile section */
 		750379A0254A8538002A0C13 /* GridShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 7503798C254A8537002A0C13 /* GridShaders.metal */; };
 		750379A1254A8538002A0C13 /* MapRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7503798D254A8537002A0C13 /* MapRenderer.swift */; };
-		750379A2254A8538002A0C13 /* SharedShaderTypes.h in Resources */ = {isa = PBXBuildFile; fileRef = 7503798E254A8537002A0C13 /* SharedShaderTypes.h */; };
+		750379A2254A8538002A0C13 /* SharedTypes.h in Resources */ = {isa = PBXBuildFile; fileRef = 7503798E254A8537002A0C13 /* SharedTypes.h */; };
 		750379A3254A8538002A0C13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7503798F254A8538002A0C13 /* Assets.xcassets */; };
 		757DF60C254F26EE005723D5 /* ChunkGenerationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF60B254F26EE005723D5 /* ChunkGenerationState.swift */; };
 		757DF61E254F687F005723D5 /* SwiftPriorityQueue in Frameworks */ = {isa = PBXBuildFile; productRef = 757DF61D254F687F005723D5 /* SwiftPriorityQueue */; };
 		757DF621254F90CB005723D5 /* GeneraDebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF620254F90CB005723D5 /* GeneraDebugView.swift */; };
 		757DF626254FA0FF005723D5 /* DebugDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF625254FA0FF005723D5 /* DebugDelegate.swift */; };
 		757E14EA255151F50036AEB5 /* Util.metal in Sources */ = {isa = PBXBuildFile; fileRef = 757E14E9255151F50036AEB5 /* Util.metal */; };
+		757E151225525B750036AEB5 /* VertexProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757E151125525B750036AEB5 /* VertexProtocol.swift */; };
 		759E000A254E16FC004CF89F /* VectoredDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759E0009254E16FC004CF89F /* VectoredDirection.swift */; };
 		759EFFFC254DE361004CF89F /* GeneraMTLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759EFFFB254DE361004CF89F /* GeneraMTLView.swift */; };
 		75B2B74C254B68FB00351DC8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 75B2B747254B68FB00351DC8 /* Main.storyboard */; };
@@ -43,7 +44,7 @@
 /* Begin PBXFileReference section */
 		7503798C254A8537002A0C13 /* GridShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = GridShaders.metal; sourceTree = "<group>"; };
 		7503798D254A8537002A0C13 /* MapRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapRenderer.swift; sourceTree = "<group>"; };
-		7503798E254A8537002A0C13 /* SharedShaderTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedShaderTypes.h; sourceTree = "<group>"; };
+		7503798E254A8537002A0C13 /* SharedTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SharedTypes.h; sourceTree = "<group>"; };
 		7503798F254A8538002A0C13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		75037994254A8538002A0C13 /* Genera.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Genera.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		757DF60B254F26EE005723D5 /* ChunkGenerationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkGenerationState.swift; sourceTree = "<group>"; };
@@ -51,6 +52,9 @@
 		757DF625254FA0FF005723D5 /* DebugDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDelegate.swift; sourceTree = "<group>"; };
 		757E14E9255151F50036AEB5 /* Util.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Util.metal; sourceTree = "<group>"; };
 		757E14EC2551525D0036AEB5 /* Util.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Util.h; sourceTree = "<group>"; };
+		757E14FF25523B0D0036AEB5 /* TerrainShaderTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TerrainShaderTypes.h; sourceTree = "<group>"; };
+		757E150025523B210036AEB5 /* GridShaderTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridShaderTypes.h; sourceTree = "<group>"; };
+		757E151125525B750036AEB5 /* VertexProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VertexProtocol.swift; sourceTree = "<group>"; };
 		759E0009254E16FC004CF89F /* VectoredDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectoredDirection.swift; sourceTree = "<group>"; };
 		759EFFFB254DE361004CF89F /* GeneraMTLView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneraMTLView.swift; sourceTree = "<group>"; };
 		75B2B745254B68FB00351DC8 /* GeneraMacOS.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = GeneraMacOS.entitlements; sourceTree = "<group>"; };
@@ -106,8 +110,10 @@
 			children = (
 				757E14EC2551525D0036AEB5 /* Util.h */,
 				757E14E9255151F50036AEB5 /* Util.metal */,
-				7503798E254A8537002A0C13 /* SharedShaderTypes.h */,
+				7503798E254A8537002A0C13 /* SharedTypes.h */,
+				757E150025523B210036AEB5 /* GridShaderTypes.h */,
 				7503798C254A8537002A0C13 /* GridShaders.metal */,
+				757E14FF25523B0D0036AEB5 /* TerrainShaderTypes.h */,
 				75C4B4B52550062600F36372 /* TerrainShaders.metal */,
 			);
 			path = metal;
@@ -177,12 +183,13 @@
 			isa = PBXGroup;
 			children = (
 				75FA6D77254D2DFA00A1B409 /* Size.swift */,
-				75B90874254B796A00231E39 /* Tile.swift */,
 				75FA6D33254BF37400A1B409 /* Chunk.swift */,
+				75B90874254B796A00231E39 /* Tile.swift */,
 				75FA6D43254C09F200A1B409 /* Direction.swift */,
 				759E0009254E16FC004CF89F /* VectoredDirection.swift */,
 				75FA6D7F254D3D7200A1B409 /* ZoomDirection.swift */,
 				75FA6D7B254D35D000A1B409 /* Color.swift */,
+				757E151125525B750036AEB5 /* VertexProtocol.swift */,
 			);
 			path = "data structures";
 			sourceTree = "<group>";
@@ -274,7 +281,7 @@
 			files = (
 				75B2B74C254B68FB00351DC8 /* Main.storyboard in Resources */,
 				750379A3254A8538002A0C13 /* Assets.xcassets in Resources */,
-				750379A2254A8538002A0C13 /* SharedShaderTypes.h in Resources */,
+				750379A2254A8538002A0C13 /* SharedTypes.h in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -308,6 +315,7 @@
 				75B2B74D254B68FB00351DC8 /* AppDelegate.swift in Sources */,
 				757DF60C254F26EE005723D5 /* ChunkGenerationState.swift in Sources */,
 				75C4B4B0254FE57F00F36372 /* Logger.swift in Sources */,
+				757E151225525B750036AEB5 /* VertexProtocol.swift in Sources */,
 				75FA6D34254BF37400A1B409 /* Chunk.swift in Sources */,
 				75FA6D60254CE2A300A1B409 /* GameCoordinator.swift in Sources */,
 				75FA6D44254C09F200A1B409 /* Direction.swift in Sources */,
@@ -460,7 +468,7 @@
 				PRODUCT_NAME = Genera;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = metal/SharedShaderTypes.h;
+				SWIFT_OBJC_BRIDGING_HEADER = metal/SharedTypes.h;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -485,7 +493,7 @@
 				PRODUCT_NAME = Genera;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_OBJC_BRIDGING_HEADER = metal/SharedShaderTypes.h;
+				SWIFT_OBJC_BRIDGING_HEADER = metal/SharedTypes.h;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		75B2B764254B71AD00351DC8 /* BasicGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2B763254B71AC00351DC8 /* BasicGenerator.swift */; };
 		75B90871254B747400231E39 /* ViewportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B90870254B747400231E39 /* ViewportCoordinator.swift */; };
 		75B90875254B796A00231E39 /* Tile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B90874254B796A00231E39 /* Tile.swift */; };
+		75C4B4B0254FE57F00F36372 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C4B4AF254FE57F00F36372 /* Logger.swift */; };
 		75FA6D31254BF07A00A1B409 /* MapUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */; };
 		75FA6D34254BF37400A1B409 /* Chunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D33254BF37400A1B409 /* Chunk.swift */; };
 		75FA6D37254BF80D00A1B409 /* GeneratorDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */; };
@@ -55,6 +56,7 @@
 		75B2B763254B71AC00351DC8 /* BasicGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicGenerator.swift; sourceTree = "<group>"; };
 		75B90870254B747400231E39 /* ViewportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportCoordinator.swift; sourceTree = "<group>"; };
 		75B90874254B796A00231E39 /* Tile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tile.swift; sourceTree = "<group>"; };
+		75C4B4AF254FE57F00F36372 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapUpdateDelegate.swift; sourceTree = "<group>"; };
 		75FA6D33254BF37400A1B409 /* Chunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chunk.swift; sourceTree = "<group>"; };
 		75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorDataDelegate.swift; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 				75B2B744254B68FB00351DC8 /* macOS */,
 				7503798B254A8537002A0C13 /* metal */,
 				75FA6D5E254CE20300A1B409 /* game */,
+				75C4B4AE254FE56600F36372 /* utility */,
 				75B2B75A254B6F6E00351DC8 /* config */,
 				75037995254A8538002A0C13 /* Products */,
 			);
@@ -141,6 +144,14 @@
 				75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */,
 			);
 			path = rendering;
+			sourceTree = "<group>";
+		};
+		75C4B4AE254FE56600F36372 /* utility */ = {
+			isa = PBXGroup;
+			children = (
+				75C4B4AF254FE57F00F36372 /* Logger.swift */,
+			);
+			path = utility;
 			sourceTree = "<group>";
 		};
 		75FA6D54254CD8B500A1B409 /* generation */ = {
@@ -286,6 +297,7 @@
 				75FA6D73254CEB0400A1B409 /* GeneratorProtocol.swift in Sources */,
 				75B2B74D254B68FB00351DC8 /* AppDelegate.swift in Sources */,
 				757DF60C254F26EE005723D5 /* ChunkGenerationState.swift in Sources */,
+				75C4B4B0254FE57F00F36372 /* Logger.swift in Sources */,
 				75FA6D34254BF37400A1B409 /* Chunk.swift in Sources */,
 				75FA6D60254CE2A300A1B409 /* GameCoordinator.swift in Sources */,
 				75FA6D44254C09F200A1B409 /* Direction.swift in Sources */,

--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		75B90871254B747400231E39 /* ViewportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B90870254B747400231E39 /* ViewportCoordinator.swift */; };
 		75B90875254B796A00231E39 /* Tile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B90874254B796A00231E39 /* Tile.swift */; };
 		75C4B4B0254FE57F00F36372 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C4B4AF254FE57F00F36372 /* Logger.swift */; };
+		75C4B4B62550062600F36372 /* SimplexShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 75C4B4B52550062600F36372 /* SimplexShaders.metal */; };
 		75FA6D31254BF07A00A1B409 /* MapUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */; };
 		75FA6D34254BF37400A1B409 /* Chunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D33254BF37400A1B409 /* Chunk.swift */; };
 		75FA6D37254BF80D00A1B409 /* GeneratorDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */; };
@@ -57,6 +58,7 @@
 		75B90870254B747400231E39 /* ViewportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportCoordinator.swift; sourceTree = "<group>"; };
 		75B90874254B796A00231E39 /* Tile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tile.swift; sourceTree = "<group>"; };
 		75C4B4AF254FE57F00F36372 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		75C4B4B52550062600F36372 /* SimplexShaders.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = SimplexShaders.metal; sourceTree = "<group>"; };
 		75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapUpdateDelegate.swift; sourceTree = "<group>"; };
 		75FA6D33254BF37400A1B409 /* Chunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chunk.swift; sourceTree = "<group>"; };
 		75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorDataDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				7503798C254A8537002A0C13 /* SimpleShaders.metal */,
+				75C4B4B52550062600F36372 /* SimplexShaders.metal */,
 				7503798E254A8537002A0C13 /* SimpleShaderTypes.h */,
 			);
 			path = metal;
@@ -290,6 +293,7 @@
 				75FA6D50254C91CE00A1B409 /* ViewportDataDelegate.swift in Sources */,
 				75FA6D40254C098500A1B409 /* ViewportChangeDelegate.swift in Sources */,
 				75FA6D80254D3D7200A1B409 /* ZoomDirection.swift in Sources */,
+				75C4B4B62550062600F36372 /* SimplexShaders.metal in Sources */,
 				75FA6D31254BF07A00A1B409 /* MapUpdateDelegate.swift in Sources */,
 				757DF621254F90CB005723D5 /* GeneraDebugView.swift in Sources */,
 				750379A0254A8538002A0C13 /* SimpleShaders.metal in Sources */,

--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -19,11 +19,11 @@
 		759EFFFC254DE361004CF89F /* GeneraMTLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 759EFFFB254DE361004CF89F /* GeneraMTLView.swift */; };
 		75B2B74C254B68FB00351DC8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 75B2B747254B68FB00351DC8 /* Main.storyboard */; };
 		75B2B74D254B68FB00351DC8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2B749254B68FB00351DC8 /* AppDelegate.swift */; };
-		75B2B764254B71AD00351DC8 /* BasicGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2B763254B71AC00351DC8 /* BasicGenerator.swift */; };
+		75B2B764254B71AD00351DC8 /* RandomTileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B2B763254B71AC00351DC8 /* RandomTileGenerator.swift */; };
 		75B90871254B747400231E39 /* ViewportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B90870254B747400231E39 /* ViewportCoordinator.swift */; };
 		75B90875254B796A00231E39 /* Tile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B90874254B796A00231E39 /* Tile.swift */; };
 		75C4B4B0254FE57F00F36372 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C4B4AF254FE57F00F36372 /* Logger.swift */; };
-		75C4B4B62550062600F36372 /* SimplexShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 75C4B4B52550062600F36372 /* SimplexShaders.metal */; };
+		75C4B4B62550062600F36372 /* TerrainShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 75C4B4B52550062600F36372 /* TerrainShaders.metal */; };
 		75FA6D31254BF07A00A1B409 /* MapUpdateDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */; };
 		75FA6D34254BF37400A1B409 /* Chunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D33254BF37400A1B409 /* Chunk.swift */; };
 		75FA6D37254BF80D00A1B409 /* GeneratorDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */; };
@@ -54,11 +54,11 @@
 		75B2B748254B68FB00351DC8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		75B2B749254B68FB00351DC8 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		75B2B74A254B68FB00351DC8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		75B2B763254B71AC00351DC8 /* BasicGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicGenerator.swift; sourceTree = "<group>"; };
+		75B2B763254B71AC00351DC8 /* RandomTileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomTileGenerator.swift; sourceTree = "<group>"; };
 		75B90870254B747400231E39 /* ViewportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportCoordinator.swift; sourceTree = "<group>"; };
 		75B90874254B796A00231E39 /* Tile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tile.swift; sourceTree = "<group>"; };
 		75C4B4AF254FE57F00F36372 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		75C4B4B52550062600F36372 /* SimplexShaders.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = SimplexShaders.metal; sourceTree = "<group>"; };
+		75C4B4B52550062600F36372 /* TerrainShaders.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = TerrainShaders.metal; sourceTree = "<group>"; };
 		75FA6D30254BF07A00A1B409 /* MapUpdateDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapUpdateDelegate.swift; sourceTree = "<group>"; };
 		75FA6D33254BF37400A1B409 /* Chunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chunk.swift; sourceTree = "<group>"; };
 		75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorDataDelegate.swift; sourceTree = "<group>"; };
@@ -102,7 +102,7 @@
 			isa = PBXGroup;
 			children = (
 				7503798C254A8537002A0C13 /* SimpleShaders.metal */,
-				75C4B4B52550062600F36372 /* SimplexShaders.metal */,
+				75C4B4B52550062600F36372 /* TerrainShaders.metal */,
 				7503798E254A8537002A0C13 /* SimpleShaderTypes.h */,
 			);
 			path = metal;
@@ -162,8 +162,8 @@
 			children = (
 				75FA6D72254CEB0400A1B409 /* GeneratorProtocol.swift */,
 				75FA6D36254BF80D00A1B409 /* GeneratorDataDelegate.swift */,
-				75B2B763254B71AC00351DC8 /* BasicGenerator.swift */,
 				757DF60B254F26EE005723D5 /* ChunkGenerationState.swift */,
+				75B2B763254B71AC00351DC8 /* RandomTileGenerator.swift */,
 			);
 			path = generation;
 			sourceTree = "<group>";
@@ -293,11 +293,11 @@
 				75FA6D50254C91CE00A1B409 /* ViewportDataDelegate.swift in Sources */,
 				75FA6D40254C098500A1B409 /* ViewportChangeDelegate.swift in Sources */,
 				75FA6D80254D3D7200A1B409 /* ZoomDirection.swift in Sources */,
-				75C4B4B62550062600F36372 /* SimplexShaders.metal in Sources */,
+				75C4B4B62550062600F36372 /* TerrainShaders.metal in Sources */,
 				75FA6D31254BF07A00A1B409 /* MapUpdateDelegate.swift in Sources */,
 				757DF621254F90CB005723D5 /* GeneraDebugView.swift in Sources */,
 				750379A0254A8538002A0C13 /* SimpleShaders.metal in Sources */,
-				75B2B764254B71AD00351DC8 /* BasicGenerator.swift in Sources */,
+				75B2B764254B71AD00351DC8 /* RandomTileGenerator.swift in Sources */,
 				75FA6D73254CEB0400A1B409 /* GeneratorProtocol.swift in Sources */,
 				75B2B74D254B68FB00351DC8 /* AppDelegate.swift in Sources */,
 				757DF60C254F26EE005723D5 /* ChunkGenerationState.swift in Sources */,

--- a/game/GameCoordinator.swift
+++ b/game/GameCoordinator.swift
@@ -23,7 +23,7 @@ class GameCoordinator {
     /// Initialization will fail if Metal is missing or the renderer isn't
     /// created correctly. Otherwise, sets everything up.
     init?(view: GeneraMTLView, debugView: GeneraDebugView?) {
-        let generator = BasicGenerator()
+        let generator = RandomTileGenerator()
         guard let defaultDevice = MTLCreateSystemDefaultDevice(),
               let renderer = MapRenderer(view: view, device: defaultDevice, generatorDataDelegate: generator) else {
             assertionFailure("Game coordinator cannot be initialized")

--- a/game/GameCoordinator.swift
+++ b/game/GameCoordinator.swift
@@ -7,23 +7,24 @@
 
 import MetalKit
 
-/**
- Coordinates all of the game generation, rendering, and viewports
- */
+/// Coordinates all of the game generation, rendering, and viewports
 class GameCoordinator {
+    
+    /// This determines which type of map we're generating
+    typealias GeneratorType = RandomTileGenerator
     
     // MARK: variables
     
-    private let generator: GeneratorProtocol & GeneratorDataDelegate
+    private let generator: GeneratorType
     private let viewportCoordinator: ViewportCoordinator
-    private let renderer: MapRenderer
+    private let renderer: MapRenderer<GeneratorType>
     
     // MARK: initialization
     
     /// Initialization will fail if Metal is missing or the renderer isn't
     /// created correctly. Otherwise, sets everything up.
     init?(view: GeneraMTLView, debugView: GeneraDebugView?) {
-        let generator = RandomTileGenerator()
+        let generator = GeneratorType()
         guard let defaultDevice = MTLCreateSystemDefaultDevice(),
               let renderer = MapRenderer(view: view, device: defaultDevice, generatorDataDelegate: generator) else {
             assertionFailure("Game coordinator cannot be initialized")

--- a/game/data structures/Chunk.swift
+++ b/game/data structures/Chunk.swift
@@ -47,3 +47,33 @@ struct DatedChunk: Hashable, Comparable {
         hasher.combine(value)
     }
 }
+
+/// Represents a chunk that has a count, used for comparing
+struct CountedChunk: Hashable, Comparable {
+    let value: Chunk
+    let count: Int
+    
+    static func < (lhs: CountedChunk, rhs: CountedChunk) -> Bool {
+        return lhs.count < rhs.count
+    }
+    
+    init(_ chunk: Chunk, count: Int = 0) {
+        self.value = chunk
+        self.count = count
+    }
+    
+    /// Two dated chunks are equivalent if their chunks are the same (count doesn't matter)
+    static func == (lhs: CountedChunk, rhs: CountedChunk) -> Bool {
+        return lhs.value == rhs.value
+    }
+    
+    /// Just hash the chunk itself
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
+    }
+    
+    /// Returns a new counted chunk that's been incremented by 1
+    func incremented() -> CountedChunk {
+        return CountedChunk(value, count: count + 1)
+    }
+}

--- a/game/data structures/Color.swift
+++ b/game/data structures/Color.swift
@@ -6,18 +6,19 @@
 //
 
 import Cocoa
+import simd
 
 /// Useful color function manipulations
 enum Color {
     
-    /// Converts a color into its components, as a float array
-    static func components(from color: NSColor) -> [Float] {
-        return [
+    /// Converts a color into its components, as a simd_float4
+    static func components(from color: NSColor) -> simd_float4 {
+        return simd_float4(
             Float(color.redComponent),
             Float(color.greenComponent),
             Float(color.blueComponent),
             Float(color.alphaComponent)
-        ]
+        )
     }
 
 }

--- a/game/data structures/Size.swift
+++ b/game/data structures/Size.swift
@@ -32,7 +32,7 @@ enum Size {
     static let tileWidthInPixels = 12
     
     /// The width or height of a chunk, in number of tiles
-    static let chunk = 128
+    static let chunk = 64
     
     /// The width or height of a chunk, in pixels
     static let chunkInPixels = tileWidthInPixels * chunk

--- a/game/data structures/Size.swift
+++ b/game/data structures/Size.swift
@@ -29,7 +29,7 @@ enum Size {
     static let verticesPerChunk = Size.verticesPerTile * Size.chunk * Size.chunk
     
     /// The size of one tile, rendered, in pixels
-    static let tileWidthInPixels = 36
+    static let tileWidthInPixels = 12
     
     /// The width or height of a chunk, in number of tiles
     static let chunk = 128

--- a/game/data structures/Size.swift
+++ b/game/data structures/Size.swift
@@ -10,18 +10,6 @@ import Foundation
 /// A collection of common sizes/configurations used throughout generation, rendering, and data structures
 enum Size {
     
-    /// The size in bytes of one datum, used in pointer math, etc
-    static let datum = MemoryLayout<Float>.stride
-    
-    /// The size of one vertex grouping (x and y only)
-    static let vertexGrouping = 2
-    
-    /// The size of one color grouping (r, g, b, alpha)
-    static let colorGrouping = 4
-    
-    /// The size of one viewport grouping (origin.x, origin.y, width, height)
-    static let viewportGrouping = 4
-    
     /// The number of vertices in all polygons in one tile (two triangles, 3 vertices each)
     static let verticesPerTile = 6
     
@@ -36,20 +24,4 @@ enum Size {
     
     /// The width or height of a chunk, in pixels
     static let chunkInPixels = tileWidthInPixels * chunk
-}
-
-/// A collection of buffer sizes for various data structures
-enum BufferSize {
-    
-    /// Size of an array of all vertices making up one tile
-    private static let tileVertices = Size.verticesPerTile * Size.datum * Size.vertexGrouping
-    
-    /// Size of an array of all vertices making up one chunk
-    static let chunkVertices = tileVertices * Size.chunk * Size.chunk
-    
-    /// Size of an array of all colors making up one tile (assuming one per vertex)
-    private static let tileColors = Size.verticesPerTile * Size.datum * Size.colorGrouping
-    
-    /// Size of an array of all colors making up one chunk
-    static let chunkColors = tileColors * Size.chunk * Size.chunk
 }

--- a/game/data structures/Tile.swift
+++ b/game/data structures/Tile.swift
@@ -38,7 +38,7 @@ struct Tile {
         static let total = 6
         
         /// The corresponding tile color, expressed as a 4 item float array from 0...1
-        var color: [Float] {
+        var color: simd_float4 {
             switch self {
             case .water:
                 return Color.components(from: #colorLiteral(red: 0, green: 0.4784313725, blue: 1, alpha: 1))
@@ -58,33 +58,42 @@ struct Tile {
     
     // MARK: - variables
     
-    let x: Float
-    let y: Float
+    let x: Int
+    let y: Int
     let kind: Kind
     
     init(x: Int, y: Int, kind: Kind = .water) {
-        self.x = Float(x)
-        self.y = Float(y)
+        self.x = x
+        self.y = y
         self.kind = kind
         
     }
     
-    /// An array of xy vertices, with which to draw multiple triangles
-    var vertices: [Float] {
-        return [
-            x, y,
-            x + 1, y + 1,
-            x + 1, y,
-            x, y + 1,
-            x + 1, y + 1,
-            x, y,
+    /// Returns all vertices for this tile, with positions and colors!
+    var vertices: [GridVertex] {
+        return positions.map { GridVertex(position: $0, color: color) }
+    }
+    
+    /// An array of xy vertices, with which to draw multiple triangles, sized to pixels
+    private var positions: [simd_float2] {
+        let vector: (Int, Int) -> simd_float2 = { (x, y) in
+            return simd_float2(Float(x * Size.tileWidthInPixels), Float(y * Size.tileWidthInPixels))
+        }
+        let triangle1: [simd_float2] = [
+            vector(x, y),
+            vector(x + 1, y + 1),
+            vector(x + 1, y)
         ]
+        let triangle2: [simd_float2] = [
+            vector(x, y + 1),
+            vector(x + 1, y + 1),
+            vector(x, y),
+        ]
+        return triangle1 + triangle2
     }
     
     /// Color array, one rgba color for each vertex
-    var colors: [Float] {
-        return (0..<Size.verticesPerTile).flatMap({ _ in
-            return kind.color
-        })
+    private var color: simd_float4 {
+        return kind.color
     }
 }

--- a/game/data structures/VertexProtocol.swift
+++ b/game/data structures/VertexProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  VertexProtocol.swift
+//  Genera
+//
+//  Created by Dylan Gattey on 11/3/20.
+//
+
+import Foundation
+
+/// Defines a reusable vertex type our shared vertices can use
+protocol VertexProtocol {
+    
+    /// The position of this vertex
+    var position: simd_float2 { get }
+
+}
+
+extension GridVertex: VertexProtocol {}
+extension TerrainVertex: VertexProtocol {}

--- a/game/generation/BasicGenerator.swift
+++ b/game/generation/BasicGenerator.swift
@@ -208,6 +208,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
         }
         let oldTiles = chunks.removeValue(forKey: evictableChunk.value)
         Logger.log("~Evict~ removed a chunk: \(evictableChunk.value) to leave \(chunks.count) in \(paddedVisibleRanges)")
+        debugDelegate?.didUpdateNumGeneratedChunks(to: chunks.count)
         chunkAccessSemaphore.signal()
         
         // Only notify if we actually removed something (as we may have already removed this guy)

--- a/game/generation/BasicGenerator.swift
+++ b/game/generation/BasicGenerator.swift
@@ -168,10 +168,10 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
             _ = recentlyAccessedChunks.pop()
         } else if recentlyAccessedChunks.contains(datedChunk) {
             recentlyAccessedChunks.remove(datedChunk)
+            Logger.log("+++ replacing \(datedChunk)")
         }
         // Replace whatever was there with newly-dated data
         recentlyAccessedChunks.push(datedChunk)
-        print("+++ recent\(datedChunk)")
     }
     
     /// Evicts one chunk at a time, assuming this is called on a loop from a background
@@ -183,7 +183,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
         
         // Cancel the runner of this function for perf if there's nothing to evict
         guard excessChunks > 0, let evictableChunk = leastRecentChunk else {
-            print("~Evict~ finished evicting: \(excessChunks)")
+            Logger.log("~Evict~ finished evicting: \(excessChunks)")
             chunkAccessSemaphore.signal()
             evictionEventLoop?.cancel()
             evictionEventLoop = nil
@@ -193,7 +193,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
         // If it's within the visible range, mark as accessed recently (and the element will move
         // so the next iteration of this eviction loop should get a different element)
         guard !evictableChunk.value.isWithin(paddedVisibleRanges) else {
-            print("~Evict~ in viewport (total \(excessChunks) and \(recentlyAccessedChunks.count)) \(evictableChunk)")
+            Logger.log("~Evict~ in viewport (total \(excessChunks) and \(recentlyAccessedChunks.count)) \(evictableChunk)")
             unsafelyMarkChunkAsRecentlyAccessed(evictableChunk.value)
             chunkAccessSemaphore.signal()
             return
@@ -207,7 +207,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
             assertionFailure("Invariant of recently accessed chunks didn't hold")
         }
         let oldTiles = chunks.removeValue(forKey: evictableChunk.value)
-        print("~Evict~ removed a chunk: \(evictableChunk.value) to leave \(chunks.count) in \(paddedVisibleRanges)")
+        Logger.log("~Evict~ removed a chunk: \(evictableChunk.value) to leave \(chunks.count) in \(paddedVisibleRanges)")
         chunkAccessSemaphore.signal()
         
         // Only notify if we actually removed something (as we may have already removed this guy)
@@ -229,7 +229,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
         let excessChunks = chunks.count - maxChunksInMemory
         chunkAccessSemaphore.signal()
         guard excessChunks > 0 else {
-            print("~Evict~ no excess (\(excessChunks))")
+            Logger.log("~Evict~ no excess (\(excessChunks))")
             return
         }
         

--- a/game/generation/GeneratorDataDelegate.swift
+++ b/game/generation/GeneratorDataDelegate.swift
@@ -10,13 +10,19 @@ import Foundation
 // A protocol any generator of data must conform to
 protocol GeneratorDataDelegate: GeneratorProtocol {
     
+    /// The type of the vertex in the buffer + used for sizing
+    associatedtype VertexType: VertexProtocol
+    
     /// Which shader names to use in generation
     var shaders: (vertex: String, fragment: String) { get }
     
-    // Gets vertices for a particular chunk
-    func vertices(for chunk: Chunk) -> [Float]
+    /// Total size of the vertex array for one chunk of data (in bytes)
+    var verticesBufferSize: Int { get }
     
-    // Gets colors for a particular chunk
-    func colors(for chunk: Chunk) -> [Float]
+    /// Memory layout stride for the VertexType - can't be done "reflectively"
+    var stride: Int { get }
+    
+    /// Returns vertex data for a particular chunk in the form of an array
+    func vertices(for chunk: Chunk) -> [VertexType]
     
 }

--- a/game/generation/GeneratorDataDelegate.swift
+++ b/game/generation/GeneratorDataDelegate.swift
@@ -10,6 +10,9 @@ import Foundation
 // A protocol any generator of data must conform to
 protocol GeneratorDataDelegate: GeneratorProtocol {
     
+    /// Which shader names to use in generation
+    var shaders: (vertex: String, fragment: String) { get }
+    
     // Gets vertices for a particular chunk
     func vertices(for chunk: Chunk) -> [Float]
     

--- a/game/generation/GeneratorProtocol.swift
+++ b/game/generation/GeneratorProtocol.swift
@@ -13,6 +13,9 @@ protocol GeneratorProtocol: NSObject {
     /// This should be weakly held - debug delegate for all kinds of updates
     var debugDelegate: DebugDelegate? { get set }
     
+    /// This should be weakly held - used to find out what's visible
+    var viewportDataDelegate: ViewportDataDelegate? { get set }
+    
     /// Starts generating the map itself
     func startMapGeneration() -> Void
     

--- a/game/generation/RandomTileGenerator.swift
+++ b/game/generation/RandomTileGenerator.swift
@@ -18,6 +18,9 @@ class RandomTileGenerator: NSObject, GeneratorDataDelegate {
     /// The length of the event loops where we process evictions + generate
     private static let eventLoopInterval: DispatchQueue.SchedulerTimeType.Stride = .milliseconds(1)
     
+    /// The names of the shaders to use with this generator
+    private static let shaderNames = (vertex: "gridVertexShader", fragment: "gridFragmentShader")
+    
     // MARK: variables
     
     /// Basic dict of chunk -> array of tiles
@@ -69,6 +72,11 @@ class RandomTileGenerator: NSObject, GeneratorDataDelegate {
     }
     
     // MARK: - GeneratorDataDelegate
+    
+    /// Which shader names to use in generation
+    var shaders: (vertex: String, fragment: String) {
+        return RandomTileGenerator.shaderNames
+    }
     
     /// Returns vertices for a particular chunk of data if it exists, or nil (and marks it as recently accessed for use in eviction)
     func vertices(for chunk: Chunk) -> [Float] {

--- a/game/generation/RandomTileGenerator.swift
+++ b/game/generation/RandomTileGenerator.swift
@@ -1,5 +1,5 @@
 //
-//  BasicGenerator.swift
+//  RandomTileGenerator.swift
 //  Genera
 //
 //  Created by Dylan Gattey on 10/29/20.
@@ -11,7 +11,7 @@ import Combine
 import SwiftPriorityQueue
 
 /// Just generates a totally random map
-class BasicGenerator: NSObject, GeneratorDataDelegate {
+class RandomTileGenerator: NSObject, GeneratorDataDelegate {
     
     // MARK: constants
     
@@ -243,7 +243,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
         // We have too many chunks - let's evict until we have nothing new to evict
         evictionEventLoop = DispatchQueue.global(qos: .userInteractive).schedule(
             after: DispatchQueue.SchedulerTimeType(.now()),
-            interval: BasicGenerator.eventLoopInterval,
+            interval: RandomTileGenerator.eventLoopInterval,
             evictOldestChunk)
     }
     
@@ -251,7 +251,7 @@ class BasicGenerator: NSObject, GeneratorDataDelegate {
 
 // MARK: - GenerationDelegate
 
-extension BasicGenerator: GeneratorProtocol {
+extension RandomTileGenerator: GeneratorProtocol {
     
     /// Just generates visible chunks to start with
     func startMapGeneration() {
@@ -301,7 +301,7 @@ extension BasicGenerator: GeneratorProtocol {
         if (generationEventLoop == nil) {
             generationEventLoop = DispatchQueue.global(qos: .userInteractive).schedule(
                 after: DispatchQueue.SchedulerTimeType(.now()),
-                interval: BasicGenerator.eventLoopInterval,
+                interval: RandomTileGenerator.eventLoopInterval,
                 generateClosestTile)
         }
     }

--- a/game/rendering/MapRenderer.swift
+++ b/game/rendering/MapRenderer.swift
@@ -200,7 +200,7 @@ extension MapRenderer: MapUpdateDelegate {
         }
         
         // Then dispatch to the background to populate them
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let strongSelf = self else {
                 assertionFailure("No \(chunk) set up yet or self missing: \(String(describing: self)) | \(String(describing: buffers))")
                 return

--- a/game/rendering/MapRenderer.swift
+++ b/game/rendering/MapRenderer.swift
@@ -93,7 +93,7 @@ class MapRenderer: NSObject {
         do {
             try stateObject = device.makeRenderPipelineState(descriptor: descriptor)
         } catch let error {
-            print("Couldn't create render pipeline state object: \(error)")
+            assertionFailure("Couldn't create render pipeline state object: \(error)")
             return nil
         }
         return stateObject
@@ -146,7 +146,7 @@ extension MapRenderer: MTKViewDelegate {
     func draw(in view: MTKView) {
         guard let commandBuffer = commandQueue.makeCommandBuffer(),
               let viewport = viewportDataDelegate?.currentViewport else {
-            print("No command buffer to work with")
+            assertionFailure("No command buffer to work with")
             return
         }
         
@@ -160,7 +160,7 @@ extension MapRenderer: MTKViewDelegate {
         // In the drawing loop below here - be quick!
         guard let descriptor = view.currentRenderPassDescriptor,
               let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor) else {
-            print("Error in drawing stage")
+            assertionFailure("Error in drawing stage")
             return
         }
         

--- a/game/rendering/MapRenderer.swift
+++ b/game/rendering/MapRenderer.swift
@@ -19,10 +19,10 @@ class MapRenderer: NSObject {
     // MARK: - constants
     
     // Matches name of vertex shader in SimpleShaders
-    private static let vertexFunction = "simpleVertexShader"
+    private static let vertexFunction = "simplexVertexShader"
     
     // Matches name of fragment shader in SimpleShaders
-    private static let fragmentFunction = "simpleFragmentShader"
+    private static let fragmentFunction = "simplexFragmentShader"
     
     // Just a simple background color
     private static let backgroundColor = MTLClearColorMake(0.0, 0.5, 1.0, 1.0)

--- a/game/viewport/ViewportCoordinator.swift
+++ b/game/viewport/ViewportCoordinator.swift
@@ -24,10 +24,10 @@ class ViewportCoordinator: NSObject, ViewportDataDelegate {
     private struct ZoomLevel {
         
         /// Minimum zoom supported
-        static let min: Double = 0.4
+        static let min: Double = 0.2
         
         /// Max zoom supported
-        static let max: Double = 2.0
+        static let max: Double = 1.4
         
         /// The multiplier on the zoom amount
         static let multiplier = 0.01
@@ -51,7 +51,7 @@ class ViewportCoordinator: NSObject, ViewportDataDelegate {
     /// Converts a value to chunk space (rounded up or down depending on which side of zero we're on)
     private static func convertToChunkSpace(_ value: Double) -> Int {
         let converted = value / Double(Size.chunkInPixels)
-        return Int(value < 0 ? floor(converted) : ceil(converted))
+        return Int(round(converted))
     }
     
     /// Converts the viewport passed to a rect of visible chunks (in whole chunk-units, with 10% padding or at least one chunk)

--- a/game/viewport/ViewportCoordinator.swift
+++ b/game/viewport/ViewportCoordinator.swift
@@ -34,7 +34,7 @@ class ViewportCoordinator: NSObject, ViewportDataDelegate {
     }
     
     /// Pad by at least this amount of chunks in any direction
-    private static let minChunkPadAmount = 1
+    private static let minChunkPadAmount = 2
     
     // MARK: - static helpers
     
@@ -63,7 +63,7 @@ class ViewportCoordinator: NSObject, ViewportDataDelegate {
         let endY = convertToChunkSpace(viewport.originY + viewport.height)
 
         let pad: (Range<Int>) -> Range<Int> = { range in
-            let distance: Int = max((range.endIndex - range.startIndex) / 5, minChunkPadAmount)
+            let distance: Int = max((range.endIndex - range.startIndex) / 3, minChunkPadAmount)
             return (range.startIndex - distance ..< range.endIndex + distance)
         }
         return (pad(startX..<endX), pad(startY..<endY))

--- a/game/viewport/ViewportCoordinator.swift
+++ b/game/viewport/ViewportCoordinator.swift
@@ -33,6 +33,9 @@ class ViewportCoordinator: NSObject, ViewportDataDelegate {
         static let multiplier = 0.01
     }
     
+    /// Pad by at least this amount of chunks in any direction
+    private static let minChunkPadAmount = 1
+    
     // MARK: - static helpers
     
     /// Returns the absolute distance squared from a chunk to a pixel space point. Squared for
@@ -51,13 +54,19 @@ class ViewportCoordinator: NSObject, ViewportDataDelegate {
         return Int(value < 0 ? floor(converted) : ceil(converted))
     }
     
-    /// Converts the viewport passed to a rect of visible chunks (in whole chunk-units)
+    /// Converts the viewport passed to a rect of visible chunks (in whole chunk-units, with 10% padding or at least one chunk)
+    /// on all sides.
     private static func visibleChunks(from viewport: MTLViewport) -> (x: Range<Int>, y: Range<Int>) {
         let startX = convertToChunkSpace(viewport.originX - viewport.width)
         let startY = convertToChunkSpace(viewport.originY - viewport.height)
         let endX = convertToChunkSpace(viewport.originX + viewport.width)
         let endY = convertToChunkSpace(viewport.originY + viewport.height)
-        return ((startX..<endX), (startY..<endY))
+
+        let pad: (Range<Int>) -> Range<Int> = { range in
+            let distance: Int = max((range.endIndex - range.startIndex) / 5, minChunkPadAmount)
+            return (range.startIndex - distance ..< range.endIndex + distance)
+        }
+        return (pad(startX..<endX), pad(startY..<endY))
     }
     
     /// Convenience function for resizing a viewport to another size

--- a/macOS/Base.lproj/Main.storyboard
+++ b/macOS/Base.lproj/Main.storyboard
@@ -136,10 +136,10 @@
             </objects>
             <point key="canvasLocation" x="-689" y="300"/>
         </scene>
-        <!--Genera Split View Controller-->
+        <!--Split View Controller-->
         <scene sceneID="Obk-lJ-gL1">
             <objects>
-                <splitViewController id="cXq-wP-lTF" customClass="GeneraSplitViewController" customModule="Genera" customModuleProvider="target" sceneMemberID="viewController">
+                <splitViewController id="cXq-wP-lTF" sceneMemberID="viewController">
                     <splitViewItems>
                         <splitViewItem holdingPriority="260" id="nFi-vW-mEA"/>
                         <splitViewItem canCollapse="YES" holdingPriority="260" behavior="sidebar" id="mma-QM-U96"/>
@@ -175,125 +175,183 @@
             <objects>
                 <viewController title="Debug View Controller" id="kFq-56-eon" sceneMemberID="viewController">
                     <customView key="view" translatesAutoresizingMaskIntoConstraints="NO" id="ejV-Ib-d6d" customClass="GeneraDebugView" customModule="Genera" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="203" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="203" height="565"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FB5-ch-Ewh">
-                                <rect key="frame" x="18" y="517" width="115" height="23"/>
+                                <rect key="frame" x="18" y="482" width="115" height="23"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Debug Data" id="noG-ej-Y93">
                                     <font key="font" metaFont="systemBold" size="20"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bbm-Ii-45c">
-                                <rect key="frame" x="18" y="424" width="140" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Visible chunk bounds" id="Yut-1D-IOx">
-                                    <font key="font" metaFont="systemSemibold" size="13"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0CD-4G-BUk">
+                                <rect key="frame" x="0.0" y="60" width="203" height="385"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="3JD-nh-D50">
+                                    <rect key="frame" x="0.0" y="0.0" width="203" height="385"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <view id="muS-4b-Cpc">
+                                            <rect key="frame" x="0.0" y="0.0" width="188" height="370"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bbm-Ii-45c" userLabel="H-visibleChunks">
+                                                    <rect key="frame" x="18" y="349" width="152" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Visible chunk bounds" id="Yut-1D-IOx">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="a7x-vW-oeq" userLabel="visibleChunks">
+                                                    <rect key="frame" x="18" y="327" width="152" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="1zk-LY-bti"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="--" id="h0R-eC-dPx">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TTu-7L-Gc5" userLabel="H-numChunks">
+                                                    <rect key="frame" x="18" y="287" width="152" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Num of generated chunks" id="1Pz-ha-pBd">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="6Sz-6v-q0U" userLabel="numChunks">
+                                                    <rect key="frame" x="18" y="265" width="152" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="ibv-j0-epA"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="0" id="XsR-nd-R7M">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6dJ-Up-fW6" userLabel="H-genQueue">
+                                                    <rect key="frame" x="18" y="225" width="152" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Generation Queue" id="N2q-9Y-hvI">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="en5-GM-VD9" userLabel="genQueue">
+                                                    <rect key="frame" x="18" y="203" width="152" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="xHd-Ta-qRC"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="0" id="4CZ-uE-rtX">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H3K-4r-VxX" userLabel="H-pos">
+                                                    <rect key="frame" x="18" y="163" width="152" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="User position" id="2Qg-YR-wKx">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="WfE-O8-Wes" userLabel="pos">
+                                                    <rect key="frame" x="18" y="141" width="152" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="rYh-SU-y2T"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="--" id="dUe-sF-zLq">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Ci-Au-Rut" userLabel="H-currView">
+                                                    <rect key="frame" x="18" y="101" width="152" height="16"/>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Current viewport" id="oHn-JU-sgo">
+                                                        <font key="font" metaFont="systemSemibold" size="13"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="D0h-wq-EF8" userLabel="currView">
+                                                    <rect key="frame" x="18" y="79" width="152" height="14"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="ZeI-Yk-yja"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="--" id="fy5-QI-Ghq">
+                                                        <font key="font" metaFont="smallSystem"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="en5-GM-VD9" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="4vZ-id-bph"/>
+                                                <constraint firstItem="a7x-vW-oeq" firstAttribute="top" secondItem="bbm-Ii-45c" secondAttribute="bottom" constant="8" symbolic="YES" id="6HZ-sD-8s5"/>
+                                                <constraint firstItem="a7x-vW-oeq" firstAttribute="bottom" secondItem="TTu-7L-Gc5" secondAttribute="top" constant="-24" id="7fQ-Tj-sut"/>
+                                                <constraint firstItem="a7x-vW-oeq" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="BNd-is-qUg"/>
+                                                <constraint firstAttribute="trailing" secondItem="D0h-wq-EF8" secondAttribute="trailing" constant="20" symbolic="YES" id="CVH-Hk-0zy"/>
+                                                <constraint firstItem="WfE-O8-Wes" firstAttribute="top" secondItem="H3K-4r-VxX" secondAttribute="bottom" constant="8" symbolic="YES" id="FvA-Dv-AvX"/>
+                                                <constraint firstItem="6dJ-Up-fW6" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="H1I-1B-leh"/>
+                                                <constraint firstItem="D0h-wq-EF8" firstAttribute="top" secondItem="2Ci-Au-Rut" secondAttribute="bottom" constant="8" symbolic="YES" id="Hf7-EH-yG0"/>
+                                                <constraint firstAttribute="trailing" secondItem="bbm-Ii-45c" secondAttribute="trailing" constant="20" symbolic="YES" id="JCe-68-NRH"/>
+                                                <constraint firstItem="WfE-O8-Wes" firstAttribute="bottom" secondItem="2Ci-Au-Rut" secondAttribute="top" constant="-24" id="Jvh-a3-8yQ"/>
+                                                <constraint firstItem="2Ci-Au-Rut" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="KTa-hT-yUI"/>
+                                                <constraint firstAttribute="trailing" secondItem="2Ci-Au-Rut" secondAttribute="trailing" constant="20" symbolic="YES" id="NWl-0E-55F"/>
+                                                <constraint firstItem="en5-GM-VD9" firstAttribute="top" secondItem="6dJ-Up-fW6" secondAttribute="bottom" constant="8" symbolic="YES" id="NnI-FG-URN"/>
+                                                <constraint firstAttribute="trailing" secondItem="a7x-vW-oeq" secondAttribute="trailing" constant="20" symbolic="YES" id="NvU-Vf-H9O"/>
+                                                <constraint firstAttribute="trailing" secondItem="en5-GM-VD9" secondAttribute="trailing" constant="20" symbolic="YES" id="Ozc-nR-dqg"/>
+                                                <constraint firstAttribute="trailing" secondItem="6dJ-Up-fW6" secondAttribute="trailing" constant="20" symbolic="YES" id="RdU-w3-JM7"/>
+                                                <constraint firstItem="bbm-Ii-45c" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="WFM-1m-HN8"/>
+                                                <constraint firstItem="TTu-7L-Gc5" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="Wjh-fC-YET"/>
+                                                <constraint firstAttribute="trailing" secondItem="TTu-7L-Gc5" secondAttribute="trailing" constant="20" symbolic="YES" id="ZXT-FO-kyt"/>
+                                                <constraint firstAttribute="trailing" secondItem="WfE-O8-Wes" secondAttribute="trailing" constant="20" symbolic="YES" id="ZzY-6b-dZi"/>
+                                                <constraint firstItem="WfE-O8-Wes" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="eHJ-lB-WWT"/>
+                                                <constraint firstItem="6Sz-6v-q0U" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="exx-1j-Dzp"/>
+                                                <constraint firstAttribute="trailing" secondItem="H3K-4r-VxX" secondAttribute="trailing" constant="20" symbolic="YES" id="h0W-MK-DeT"/>
+                                                <constraint firstItem="en5-GM-VD9" firstAttribute="bottom" secondItem="H3K-4r-VxX" secondAttribute="top" constant="-24" id="ksZ-B8-1x0"/>
+                                                <constraint firstItem="6dJ-Up-fW6" firstAttribute="top" secondItem="6Sz-6v-q0U" secondAttribute="bottom" constant="24" id="pH4-DZ-a4Q"/>
+                                                <constraint firstAttribute="trailing" secondItem="6Sz-6v-q0U" secondAttribute="trailing" constant="20" symbolic="YES" id="pfW-lb-Iwy"/>
+                                                <constraint firstItem="D0h-wq-EF8" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="s3P-W8-qse"/>
+                                                <constraint firstItem="H3K-4r-VxX" firstAttribute="leading" secondItem="muS-4b-Cpc" secondAttribute="leading" constant="20" symbolic="YES" id="uQj-xY-hkH"/>
+                                                <constraint firstItem="6Sz-6v-q0U" firstAttribute="top" secondItem="TTu-7L-Gc5" secondAttribute="bottom" constant="8" symbolic="YES" id="vcb-fx-IgM"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TTu-7L-Gc5">
-                                <rect key="frame" x="18" y="362" width="167" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Num of generated chunks" id="1Pz-ha-pBd">
-                                    <font key="font" metaFont="systemSemibold" size="13"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H3K-4r-VxX">
-                                <rect key="frame" x="18" y="300" width="88" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="User position" id="2Qg-YR-wKx">
-                                    <font key="font" metaFont="systemSemibold" size="13"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Ci-Au-Rut">
-                                <rect key="frame" x="18" y="238" width="112" height="16"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" selectable="YES" alignment="left" title="Current viewport" id="oHn-JU-sgo">
-                                    <font key="font" metaFont="systemSemibold" size="13"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="a7x-vW-oeq">
-                                <rect key="frame" x="18" y="402" width="104" height="14"/>
+                                </clipView>
                                 <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="1zk-LY-bti"/>
+                                    <constraint firstItem="bbm-Ii-45c" firstAttribute="top" secondItem="0CD-4G-BUk" secondAttribute="top" constant="20" id="JEZ-dV-Xa0"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="D0h-wq-EF8" secondAttribute="bottom" priority="200" constant="60" id="zn8-57-JCu"/>
                                 </constraints>
-                                <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="(0, 1, 1, 0)" id="h0R-eC-dPx">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="6Sz-6v-q0U">
-                                <rect key="frame" x="18" y="340" width="104" height="14"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="ibv-j0-epA"/>
-                                </constraints>
-                                <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="(0, 1, 1, 0)" id="XsR-nd-R7M">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="WfE-O8-Wes">
-                                <rect key="frame" x="18" y="278" width="104" height="14"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="rYh-SU-y2T"/>
-                                </constraints>
-                                <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="(0, 1, 1, 0)" id="dUe-sF-zLq">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="1" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="D0h-wq-EF8">
-                                <rect key="frame" x="18" y="216" width="104" height="14"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="ZeI-Yk-yja"/>
-                                </constraints>
-                                <textFieldCell key="cell" controlSize="small" selectable="YES" alignment="left" title="(0, 1, 1, 0)" id="fy5-QI-Ghq">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="3Wg-5Q-gzY">
+                                    <rect key="frame" x="-100" y="-100" width="166" height="15"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="vTX-xT-esP">
+                                    <rect key="frame" x="187" y="0.0" width="16" height="0.0"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="D0h-wq-EF8" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="2NR-wl-9go"/>
-                            <constraint firstItem="TTu-7L-Gc5" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="2Pj-L8-pv1"/>
                             <constraint firstItem="FB5-ch-Ewh" firstAttribute="top" secondItem="ejV-Ib-d6d" secondAttribute="top" constant="60" id="5VY-Lk-YH6"/>
-                            <constraint firstItem="6Sz-6v-q0U" firstAttribute="top" secondItem="TTu-7L-Gc5" secondAttribute="bottom" constant="8" symbolic="YES" id="9JA-4W-8te"/>
-                            <constraint firstItem="2Ci-Au-Rut" firstAttribute="top" secondItem="WfE-O8-Wes" secondAttribute="bottom" constant="24" id="DUb-Dt-BAo"/>
-                            <constraint firstItem="bbm-Ii-45c" firstAttribute="top" secondItem="FB5-ch-Ewh" secondAttribute="top" constant="100" id="KEU-pP-vvi"/>
-                            <constraint firstItem="TTu-7L-Gc5" firstAttribute="top" secondItem="a7x-vW-oeq" secondAttribute="bottom" constant="24" id="LnX-oI-snN"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Sz-6v-q0U" secondAttribute="trailing" constant="20" symbolic="YES" id="SJ7-Cv-KYn"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="H3K-4r-VxX" secondAttribute="trailing" constant="20" symbolic="YES" id="SMk-NO-ptQ"/>
-                            <constraint firstItem="WfE-O8-Wes" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="ULI-fc-uOz"/>
-                            <constraint firstItem="H3K-4r-VxX" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="WSS-3F-j2E"/>
+                            <constraint firstAttribute="bottom" secondItem="0CD-4G-BUk" secondAttribute="bottom" constant="60" id="9hJ-hV-0LR"/>
+                            <constraint firstAttribute="trailing" secondItem="0CD-4G-BUk" secondAttribute="trailing" id="G4q-H1-MA6"/>
                             <constraint firstItem="FB5-ch-Ewh" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="Xqj-QE-udB"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TTu-7L-Gc5" secondAttribute="trailing" constant="20" symbolic="YES" id="YhW-9f-JuB"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WfE-O8-Wes" secondAttribute="trailing" constant="20" symbolic="YES" id="ZDY-q7-uAO"/>
-                            <constraint firstItem="D0h-wq-EF8" firstAttribute="top" secondItem="2Ci-Au-Rut" secondAttribute="bottom" constant="8" symbolic="YES" id="cLK-Fc-pgu"/>
-                            <constraint firstItem="2Ci-Au-Rut" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="eBj-lM-75A"/>
-                            <constraint firstItem="a7x-vW-oeq" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="ej1-Jx-AVh"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="D0h-wq-EF8" secondAttribute="trailing" constant="20" symbolic="YES" id="jyC-3g-M80"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2Ci-Au-Rut" secondAttribute="trailing" constant="20" symbolic="YES" id="kli-DS-nww"/>
-                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="D0h-wq-EF8" secondAttribute="bottom" constant="60" id="peL-Zw-hko"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="a7x-vW-oeq" secondAttribute="trailing" constant="20" symbolic="YES" id="qvz-bh-X7q"/>
-                            <constraint firstItem="bbm-Ii-45c" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="tqx-l8-Cyn"/>
-                            <constraint firstItem="WfE-O8-Wes" firstAttribute="top" secondItem="H3K-4r-VxX" secondAttribute="bottom" constant="8" symbolic="YES" id="uIN-PN-lE9"/>
-                            <constraint firstItem="6Sz-6v-q0U" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" constant="20" symbolic="YES" id="vld-gS-Nut"/>
-                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bbm-Ii-45c" secondAttribute="trailing" constant="20" symbolic="YES" id="wNO-7s-474"/>
-                            <constraint firstItem="H3K-4r-VxX" firstAttribute="top" secondItem="6Sz-6v-q0U" secondAttribute="bottom" constant="24" id="wWn-9K-oXt"/>
+                            <constraint firstItem="0CD-4G-BUk" firstAttribute="leading" secondItem="ejV-Ib-d6d" secondAttribute="leading" id="gmM-zR-fxU"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FB5-ch-Ewh" secondAttribute="trailing" constant="20" symbolic="YES" id="z2L-9n-FiU"/>
-                            <constraint firstItem="a7x-vW-oeq" firstAttribute="top" secondItem="bbm-Ii-45c" secondAttribute="bottom" constant="8" symbolic="YES" id="zMy-UN-HVD"/>
+                            <constraint firstItem="0CD-4G-BUk" firstAttribute="top" secondItem="FB5-ch-Ewh" secondAttribute="top" constant="60" id="zPT-cN-jSR"/>
                         </constraints>
                         <connections>
                             <outlet property="currentViewport" destination="D0h-wq-EF8" id="bkg-dd-clS"/>
+                            <outlet property="generationQueue" destination="en5-GM-VD9" id="8oE-Ih-XZ6"/>
                             <outlet property="numGeneratedChunks" destination="6Sz-6v-q0U" id="87e-cP-MEp"/>
                             <outlet property="userPosition" destination="WfE-O8-Wes" id="t64-Ro-zYJ"/>
                             <outlet property="visibleChunkBounds" destination="a7x-vW-oeq" id="o6n-za-oET"/>
@@ -302,7 +360,7 @@
                 </viewController>
                 <customObject id="xgx-H1-H4b" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-391" y="1929"/>
+            <point key="canvasLocation" x="-391.5" y="1929"/>
         </scene>
     </scenes>
 </document>

--- a/macOS/DebugDelegate.swift
+++ b/macOS/DebugDelegate.swift
@@ -17,6 +17,9 @@ protocol DebugDelegate: NSObject {
     /// Called when number of generated chunks updates
     func didUpdateNumGeneratedChunks(to value: Int) -> Void
     
+    /// Called when the generation queue changes
+    func didUpdateGenerationQueue(to value: Int)
+    
     /// Called when user position in the viewport changes
     func didUpdateUserPosition(to value: MTLViewport) -> Void
     

--- a/macOS/DebugDelegate.swift
+++ b/macOS/DebugDelegate.swift
@@ -18,7 +18,7 @@ protocol DebugDelegate: NSObject {
     func didUpdateNumGeneratedChunks(to value: Int) -> Void
     
     /// Called when the generation queue changes
-    func didUpdateGenerationQueue(to value: Int)
+    func didUpdateGenerationQueue(to value: (needsGeneration: Int, inProgress: Int))
     
     /// Called when user position in the viewport changes
     func didUpdateUserPosition(to value: MTLViewport) -> Void

--- a/macOS/GeneraDebugView.swift
+++ b/macOS/GeneraDebugView.swift
@@ -14,6 +14,7 @@ class GeneraDebugView: NSView {
     
     @IBOutlet var visibleChunkBounds: NSTextField!
     @IBOutlet var numGeneratedChunks: NSTextField!
+    @IBOutlet var generationQueue: NSTextField!
     @IBOutlet var userPosition: NSTextField!
     @IBOutlet var currentViewport: NSTextField!
 
@@ -34,6 +35,10 @@ extension GeneraDebugView: DebugDelegate {
     
     func didUpdateNumGeneratedChunks(to value: Int) {
         GeneraDebugView.update(numGeneratedChunks, to: value)
+    }
+    
+    func didUpdateGenerationQueue(to value: Int) {
+        GeneraDebugView.update(generationQueue, to: value)
     }
     
     func didUpdateUserPosition(to value: MTLViewport) {

--- a/macOS/GeneraDebugView.swift
+++ b/macOS/GeneraDebugView.swift
@@ -37,7 +37,7 @@ extension GeneraDebugView: DebugDelegate {
         GeneraDebugView.update(numGeneratedChunks, to: value)
     }
     
-    func didUpdateGenerationQueue(to value: Int) {
+    func didUpdateGenerationQueue(to value: (needsGeneration: Int, inProgress: Int)) {
         GeneraDebugView.update(generationQueue, to: value)
     }
     

--- a/metal/GridShaderTypes.h
+++ b/metal/GridShaderTypes.h
@@ -1,0 +1,23 @@
+//
+//  GridShaderTypes.h
+//  Genera
+//
+//  Created by Dylan Gattey on 11/3/20.
+//
+
+#ifndef GridShaderTypes_h
+#define GridShaderTypes_h
+
+#include <simd/simd.h>
+
+/// A struct of data for one vertex to pass to the grid shaders
+struct GridVertex {
+    
+    /// The position of this vertex in 2D space
+    vector_float2 position;
+    
+    /// The color of this vertex in RGBA space
+    vector_float4 color;
+};
+
+#endif /* GridShaderTypes_h */

--- a/metal/GridShaders.metal
+++ b/metal/GridShaders.metal
@@ -1,22 +1,22 @@
 //
-//  SimpleShaders.metal
+//  GridShaders.metal
 //  Genera
 //
 //  Created by Dylan Gattey on 10/28/20.
 //
 
-// File for Metal kernel and shader functions
+// Shades tiles in a grid, using a passed in color and vertex
 
 #include <metal_stdlib>
 #include <simd/simd.h>
 
 // Including header shared between this Metal shader code and Swift/C code executing Metal API commands
-#import "SimpleShaderTypes.h"
+#import "SharedShaderTypes.h"
+#include "Util.h"
 
 using namespace metal;
 
-typedef struct
-{
+typedef struct {
     // The [[position]] attribute of this member indicates that this value
     // is the clip space position of the vertex when this structure is
     // returned from the vertex function.
@@ -26,16 +26,18 @@ typedef struct
     // interpolates its value with the values of the other triangle vertices
     // and then passes the interpolated value to the fragment shader for each
     // fragment in the triangle.
-    float4 color [[flat]];
+    float4 color;
+    
+    // Sends a color position to the fragment function
+    float2 colorPosition;
 
 } ColoredVertex;
 
 // This function creates color and position data for the vertices from viewport size
-vertex ColoredVertex simpleVertexShader(uint vertexID [[vertex_id]],
-                                        constant float2 *positions [[buffer(SimpleShaderIndexPositions)]],
-                                        constant float4 *colors [[buffer(SimpleShaderIndexColors)]],
-                                        constant float4 *viewport [[buffer(SimpleShaderIndexViewport)]])
-{
+vertex ColoredVertex gridVertexShader(uint vertexID [[vertex_id]],
+                                      constant float2 *positions [[buffer(ShaderIndexPositions)]],
+                                      constant float4 *colors [[buffer(ShaderIndexColors)]],
+                                      constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
     float2 pixelSpacePosition = positions[vertexID];
     float2 roundedPixelSpacePosition = round(pixelSpacePosition * 100) / 100;
     float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
@@ -46,11 +48,22 @@ vertex ColoredVertex simpleVertexShader(uint vertexID [[vertex_id]],
     ColoredVertex out;
     out.position = vector_float4(x, y, 0.0, 1.0);
     out.color = colors[vertexID];
+    out.colorPosition = positions[vertexID];
     return out;
 }
 
-// Use the defined color to set tile color
-fragment float4 simpleFragmentShader(ColoredVertex in [[stage_in]])
-{
+// Use the defined color to set tile color - a bit of noise
+fragment float4 gridFragmentShader(ColoredVertex in [[stage_in]]) {
     return in.color;
+}
+
+// Use the defined color to set tile color + a bit of rainbow :D
+fragment float4 gridRainbowFragmentShader(ColoredVertex in [[stage_in]]) {
+    float shadingR = simplexNoise(in.colorPosition * 0.0001);
+    float shadingG = simplexNoise(in.colorPosition * 0.0001 + 1.0);
+    float shadingB = simplexNoise(in.colorPosition * 0.0001 + 100.0);
+    float r = .9 * in.color.r + shadingR * 0.1;
+    float g = .9 * in.color.g + shadingG * 0.1;
+    float b = .9 * in.color.b + shadingB * 0.1;
+    return float4(r, g, b, 1.0);
 }

--- a/metal/GridShaders.metal
+++ b/metal/GridShaders.metal
@@ -11,8 +11,8 @@
 #include <simd/simd.h>
 
 // Including header shared between this Metal shader code and Swift/C code executing Metal API commands
-#import "SharedShaderTypes.h"
-#include "Util.h"
+#import "SharedTypes.h"
+#import "Util.h"
 
 using namespace metal;
 
@@ -31,37 +31,38 @@ typedef struct {
     // Sends a color position to the fragment function
     float2 colorPosition;
 
-} ColoredVertex;
+} FragmentVertex;
 
 // This function creates color and position data for the vertices from viewport size
-vertex ColoredVertex gridVertexShader(uint vertexID [[vertex_id]],
-                                      constant float2 *positions [[buffer(ShaderIndexPositions)]],
-                                      constant float4 *colors [[buffer(ShaderIndexColors)]],
-                                      constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
-    float2 pixelSpacePosition = positions[vertexID];
-    float2 roundedPixelSpacePosition = round(pixelSpacePosition * 100) / 100;
+vertex FragmentVertex gridVertexShader(uint vertexID [[vertex_id]],
+                                       const device GridVertex *vertexArray [[buffer(ShaderIndexVertices)]],
+                                       constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
+    float2 position = vertexArray[vertexID].position;
+    
+    // Calculate with viewport applied
+    float2 roundedPixelSpacePosition = round(position * 100) / 100;
     float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
     float2 viewportSize = float2((*viewport).z, (*viewport).w);
     float x = (roundedPixelSpacePosition.x - viewportOrigin.x) / viewportSize.x;
     float y = (roundedPixelSpacePosition.y - viewportOrigin.y) / viewportSize.y;
     
-    ColoredVertex out;
+    FragmentVertex out;
     out.position = vector_float4(x, y, 0.0, 1.0);
-    out.color = colors[vertexID];
-    out.colorPosition = positions[vertexID];
+    out.color = vertexArray[vertexID].color;
+    out.colorPosition = position;
     return out;
 }
 
-// Use the defined color to set tile color - a bit of noise
-fragment float4 gridFragmentShader(ColoredVertex in [[stage_in]]) {
+// Use the defined color to set tile color (flat)
+fragment float4 gridFragmentShader(FragmentVertex in [[stage_in]]) {
     return in.color;
 }
 
 // Use the defined color to set tile color + a bit of rainbow :D
-fragment float4 gridRainbowFragmentShader(ColoredVertex in [[stage_in]]) {
-    float shadingR = simplexNoise(in.colorPosition * 0.0001);
-    float shadingG = simplexNoise(in.colorPosition * 0.0001 + 1.0);
-    float shadingB = simplexNoise(in.colorPosition * 0.0001 + 100.0);
+fragment float4 gridRainbowFragmentShader(FragmentVertex in [[stage_in]]) {
+    float shadingR = simplexNoise(in.colorPosition * 0.00007);
+    float shadingG = simplexNoise(in.colorPosition * 0.00006 + 1.0);
+    float shadingB = simplexNoise(in.colorPosition * 0.00005 + 100.0);
     float r = .9 * in.color.r + shadingR * 0.1;
     float g = .9 * in.color.g + shadingG * 0.1;
     float b = .9 * in.color.b + shadingB * 0.1;

--- a/metal/SharedShaderTypes.h
+++ b/metal/SharedShaderTypes.h
@@ -1,5 +1,5 @@
 //
-//  SimpleShaderTypes.h
+//  SharedShaderTypes.h
 //  Genera
 //
 //  Created by Dylan Gattey on 10/28/20.
@@ -8,8 +8,8 @@
 //
 //  Header containing types and enum constants shared between Metal shaders and Swift/ObjC source
 //
-#ifndef SimpleShaderTypes_h
-#define SimpleShaderTypes_h
+#ifndef SharedShaderTypes_h
+#define SharedShaderTypes_h
 
 #ifdef __METAL_VERSION__
 #define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
@@ -20,12 +20,12 @@
 
 #include <simd/simd.h>
 
-typedef NS_ENUM(NSInteger, SimpleShaderIndex)
+typedef NS_ENUM(NSInteger, ShaderIndex)
 {
-    SimpleShaderIndexPositions  = 0,
-    SimpleShaderIndexColors  = 1,
-    SimpleShaderIndexViewport  = 2,
+    ShaderIndexPositions  = 0,
+    ShaderIndexColors  = 1,
+    ShaderIndexViewport  = 2,
 };
 
-#endif /* SimpleShaderTypes_h */
+#endif /* SharedShaderTypes_h */
 

--- a/metal/SharedTypes.h
+++ b/metal/SharedTypes.h
@@ -1,5 +1,5 @@
 //
-//  SharedShaderTypes.h
+//  SharedTypes.h
 //  Genera
 //
 //  Created by Dylan Gattey on 10/28/20.
@@ -8,8 +8,8 @@
 //
 //  Header containing types and enum constants shared between Metal shaders and Swift/ObjC source
 //
-#ifndef SharedShaderTypes_h
-#define SharedShaderTypes_h
+#ifndef SharedTypes_h
+#define SharedTypes_h
 
 #ifdef __METAL_VERSION__
 #define NS_ENUM(_type, _name) enum _name : _type _name; enum _name : _type
@@ -19,13 +19,18 @@
 #endif
 
 #include <simd/simd.h>
+#import "GridShaderTypes.h"
+#import "TerrainShaderTypes.h"
 
+/// An index for buffer indices when passing data to Metal from the app
 typedef NS_ENUM(NSInteger, ShaderIndex)
 {
-    ShaderIndexPositions  = 0,
-    ShaderIndexColors  = 1,
-    ShaderIndexViewport  = 2,
+    /// Data for the vertices themselves
+    ShaderIndexVertices = 0,
+    
+    /// Data for the viewport bounds to use in calculating normaliized positions
+    ShaderIndexViewport = 1,
 };
 
-#endif /* SharedShaderTypes_h */
+#endif /* SharedTypes_h */
 

--- a/metal/SimplexShaders.metal
+++ b/metal/SimplexShaders.metal
@@ -1,0 +1,149 @@
+//
+//  SimplexShaders.metal
+//  Genera
+//
+//  Created by Dylan Gattey on 10/28/20.
+//
+
+// File for Metal kernel and shader functions
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+// Including header shared between this Metal shader code and Swift/C code executing Metal API commands
+#import "SimpleShaderTypes.h"
+
+using namespace metal;
+
+typedef float2 u_resolution;
+typedef float2 u_mouse;
+typedef float u_time;
+
+float3 mod289(float3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+float2 mod289(float2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+float3 permute(float3 x) { return mod289(((x*34.0)+1.0)*x); }
+
+//
+// Description : GLSL 2D simplex noise function
+//      Author : Ian McEwan, Ashima Arts
+//  Maintainer : ijm
+//     Lastmod : 20110822 (ijm)
+//     License :
+//  Copyright (C) 2011 Ashima Arts. All rights reserved.
+//  Distributed under the MIT License. See LICENSE file.
+//  https://github.com/ashima/webgl-noise
+//
+float snoise(float2 v) {
+    
+    // Precompute values for skewed triangular grid
+    const float4 C = float4(0.211324865405187,
+                                          // (3.0-sqrt(3.0))/6.0
+                                          0.366025403784439,
+                                          // 0.5*(sqrt(3.0)-1.0)
+                                          -0.577350269189626,
+                                          // -1.0 + 2.0 * C.x
+                                          0.024390243902439);
+                                          // 1.0 / 41.0
+    
+    // First corner (x0)
+    float2 i  = floor(v + dot(v, C.yy));
+    float2 x0 = v - i + dot(i, C.xx);
+    
+    // Other two corners (x1, x2)
+    float2 i1 = float2(0.0);
+    i1 = (x0.x > x0.y)? float2(1.0, 0.0):float2(0.0, 1.0);
+    float2 x1 = x0.xy + C.xx - i1;
+    float2 x2 = x0.xy + C.zz;
+    
+    // Do some permutations to avoid
+    // truncation effects in permutation
+    i = mod289(i);
+    float3 p = permute(
+                     permute( i.y + float3(0.0, i1.y, 1.0))
+                     + i.x + float3(0.0, i1.x, 1.0 ));
+    
+    float3 m = max(0.5 - float3(
+                            dot(x0,x0),
+                            dot(x1,x1),
+                            dot(x2,x2)
+                            ), 0.0);
+    
+    m = m*m ;
+    m = m*m ;
+    
+    // Gradients:
+    //  41 pts uniformly over a line, mapped onto a diamond
+    //  The ring size 17*17 = 289 is close to a multiple
+    //      of 41 (41*7 = 287)
+    
+    float3 x = 2.0 * fract(p * C.www) - 1.0;
+    float3 h = abs(x) - 0.5;
+    float3 ox = floor(x + 0.5);
+    float3 a0 = x - ox;
+    
+    // Normalise gradients implicitly by scaling m
+    // Approximation of: m *= inversesqrt(a0*a0 + h*h);
+    m *= 1.79284291400159 - 0.85373472095314 * (a0*a0+h*h);
+    
+    // Compute final noise value at P
+    float3 g = float3(0.0);
+    g.x  = a0.x  * x0.x  + h.x  * x0.y;
+    g.yz = a0.yz * float2(x1.x,x2.x) + h.yz * float2(x1.y,x2.y);
+    return 130.0 * dot(m, g);
+}
+
+typedef struct
+{
+    // The [[position]] attribute of this member indicates that this value
+    // is the clip space position of the vertex when this structure is
+    // returned from the vertex function.
+    float4 position [[position]];
+    
+    // Since this member does not have a special attribute, the rasterizer
+    // interpolates its value with the values of the other triangle vertices
+    // and then passes the interpolated value to the fragment shader for each
+    // fragment in the triangle.
+    float4 color [[flat]];
+    
+} ColoredVertex;
+
+// This function creates color and position data for the vertices from viewport size
+vertex ColoredVertex simplexVertexShader(uint vertexID [[vertex_id]],
+                                        constant float2 *positions [[buffer(SimpleShaderIndexPositions)]],
+                                        constant float4 *colors [[buffer(SimpleShaderIndexColors)]],
+                                        constant float4 *viewport [[buffer(SimpleShaderIndexViewport)]])
+{
+    float2 pixelSpacePosition = positions[vertexID];
+    float2 roundedPixelSpacePosition = round(pixelSpacePosition * 100) / 100;
+    float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
+    float2 viewportSize = float2((*viewport).z, (*viewport).w);
+    float x = (roundedPixelSpacePosition.x - viewportOrigin.x) / viewportSize.x;
+    float y = (roundedPixelSpacePosition.y - viewportOrigin.y) / viewportSize.y;
+    
+    ColoredVertex out;
+    out.position = float4(x, y, 0.0, 1.0);
+    
+    float2 pos = float2(pixelSpacePosition * 0.00008 * 7.168);
+    float DF = 1.288;
+    
+    // Add a random position
+    float a = .0;
+    float2 vel = float2(0.070,0.140);
+    DF += snoise(pos+vel)*-0.710+0.290;
+    
+    // Add a random position
+    a = snoise(pos*float2(cos(0.958),sin(0.300))*-0.044)*0.029;
+    vel = float2(cos(a),sin(a));
+    DF += snoise(pos+vel)*-0.046+0.378;
+    
+    float3 color = smoothstep(0.260,0.094,fract(DF));
+    
+    out.color = float4(1.0 - color, 1.0);
+    return out;
+}
+
+// Use the defined color to set tile color
+fragment float4 simplexFragmentShader(ColoredVertex in [[stage_in]])
+{
+    return in.color;
+}

--- a/metal/TerrainShaderTypes.h
+++ b/metal/TerrainShaderTypes.h
@@ -1,0 +1,20 @@
+//
+//  TerrainShaderTypes.h
+//  Genera
+//
+//  Created by Dylan Gattey on 11/3/20.
+//
+
+#ifndef TerrainShaderTypes_h
+#define TerrainShaderTypes_h
+
+#include <simd/simd.h>
+
+/// A struct of data for one vertex to pass to the terrain shaders
+struct TerrainVertex {
+    
+    /// The position of this vertex in 2D space
+    vector_float2 position;
+};
+
+#endif /* TerrainShaderTypes_h */

--- a/metal/TerrainShaders.metal
+++ b/metal/TerrainShaders.metal
@@ -92,8 +92,7 @@ float snoise(float2 v) {
     return 130.0 * dot(m, g);
 }
 
-typedef struct
-{
+typedef struct {
     // The [[position]] attribute of this member indicates that this value
     // is the clip space position of the vertex when this structure is
     // returned from the vertex function.
@@ -111,8 +110,7 @@ typedef struct
 vertex ColoredVertex simplexVertexShader(uint vertexID [[vertex_id]],
                                         constant float2 *positions [[buffer(SimpleShaderIndexPositions)]],
                                         constant float4 *colors [[buffer(SimpleShaderIndexColors)]],
-                                        constant float4 *viewport [[buffer(SimpleShaderIndexViewport)]])
-{
+                                        constant float4 *viewport [[buffer(SimpleShaderIndexViewport)]]) {
     float2 pixelSpacePosition = positions[vertexID];
     float2 roundedPixelSpacePosition = round(pixelSpacePosition * 100) / 100;
     float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
@@ -143,7 +141,6 @@ vertex ColoredVertex simplexVertexShader(uint vertexID [[vertex_id]],
 }
 
 // Use the defined color to set tile color
-fragment float4 simplexFragmentShader(ColoredVertex in [[stage_in]])
-{
+fragment float4 simplexFragmentShader(ColoredVertex in [[stage_in]]) {
     return in.color;
 }

--- a/metal/TerrainShaders.metal
+++ b/metal/TerrainShaders.metal
@@ -11,8 +11,8 @@
 #include <simd/simd.h>
 
 // Including header shared between this Metal shader code and Swift/C code executing Metal API commands + Utils
-#import "SharedShaderTypes.h"
-#include "Util.h"
+#import "SharedTypes.h"
+#import "Util.h"
 
 using namespace metal;
 
@@ -25,27 +25,29 @@ typedef struct {
     // Need the non-transformed position for noise generation
     float2 colorPosition;
     
-} Vertex;
+} FragmentVertex;
 
 // This function creates color and position data for the vertices from viewport size
-vertex Vertex terrainVertexShader(uint vertexID [[vertex_id]],
-                                  constant float2 *positions [[buffer(ShaderIndexPositions)]],
-                                  constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
-    float2 pixelSpacePosition = positions[vertexID];
-    float2 roundedPixelSpacePosition = round(pixelSpacePosition * 100) / 100;
+vertex FragmentVertex terrainVertexShader(uint vertexID [[vertex_id]],
+                                          const device TerrainVertex *vertexArray [[buffer(ShaderIndexVertices)]],
+                                          constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
+    float2 position = vertexArray[vertexID].position;
+    
+    // Calculate with viewport applied
+    float2 roundedPixelSpacePosition = round(position * 100) / 100;
     float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
     float2 viewportSize = float2((*viewport).z, (*viewport).w);
     float x = (roundedPixelSpacePosition.x - viewportOrigin.x) / viewportSize.x;
     float y = (roundedPixelSpacePosition.y - viewportOrigin.y) / viewportSize.y;
     
-    Vertex out;
+    FragmentVertex out;
     out.position = float4(x, y, 0.0, 1.0);
-    out.colorPosition = positions[vertexID];
+    out.colorPosition = position;
     return out;
 }
 
-// Use the defined color to set tile color
-fragment float4 terrainFragmentShader(Vertex in [[stage_in]]) {
+// Use some blended fractal brownian motion to generate a modulated color
+fragment float4 terrainFragmentShader(FragmentVertex in [[stage_in]]) {
     float2 pos = float2(in.colorPosition.xy * 0.001);
     float3 color = float3(fractalBrownianMotion(pos), fractalBrownianMotion(pos - 2.0), fractalBrownianMotion(pos + 0.1));
     

--- a/metal/TerrainShaders.metal
+++ b/metal/TerrainShaders.metal
@@ -1,96 +1,20 @@
 //
-//  SimplexShaders.metal
+//  TerrainShaders.metal
 //  Genera
 //
 //  Created by Dylan Gattey on 10/28/20.
 //
 
-// File for Metal kernel and shader functions
+// File for shading terrain
 
 #include <metal_stdlib>
 #include <simd/simd.h>
 
-// Including header shared between this Metal shader code and Swift/C code executing Metal API commands
-#import "SimpleShaderTypes.h"
+// Including header shared between this Metal shader code and Swift/C code executing Metal API commands + Utils
+#import "SharedShaderTypes.h"
+#include "Util.h"
 
 using namespace metal;
-
-typedef float2 u_resolution;
-typedef float2 u_mouse;
-typedef float u_time;
-
-float3 mod289(float3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
-float2 mod289(float2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
-float3 permute(float3 x) { return mod289(((x*34.0)+1.0)*x); }
-
-//
-// Description : GLSL 2D simplex noise function
-//      Author : Ian McEwan, Ashima Arts
-//  Maintainer : ijm
-//     Lastmod : 20110822 (ijm)
-//     License :
-//  Copyright (C) 2011 Ashima Arts. All rights reserved.
-//  Distributed under the MIT License. See LICENSE file.
-//  https://github.com/ashima/webgl-noise
-//
-float snoise(float2 v) {
-    
-    // Precompute values for skewed triangular grid
-    const float4 C = float4(0.211324865405187,
-                                          // (3.0-sqrt(3.0))/6.0
-                                          0.366025403784439,
-                                          // 0.5*(sqrt(3.0)-1.0)
-                                          -0.577350269189626,
-                                          // -1.0 + 2.0 * C.x
-                                          0.024390243902439);
-                                          // 1.0 / 41.0
-    
-    // First corner (x0)
-    float2 i  = floor(v + dot(v, C.yy));
-    float2 x0 = v - i + dot(i, C.xx);
-    
-    // Other two corners (x1, x2)
-    float2 i1 = float2(0.0);
-    i1 = (x0.x > x0.y)? float2(1.0, 0.0):float2(0.0, 1.0);
-    float2 x1 = x0.xy + C.xx - i1;
-    float2 x2 = x0.xy + C.zz;
-    
-    // Do some permutations to avoid
-    // truncation effects in permutation
-    i = mod289(i);
-    float3 p = permute(
-                     permute( i.y + float3(0.0, i1.y, 1.0))
-                     + i.x + float3(0.0, i1.x, 1.0 ));
-    
-    float3 m = max(0.5 - float3(
-                            dot(x0,x0),
-                            dot(x1,x1),
-                            dot(x2,x2)
-                            ), 0.0);
-    
-    m = m*m ;
-    m = m*m ;
-    
-    // Gradients:
-    //  41 pts uniformly over a line, mapped onto a diamond
-    //  The ring size 17*17 = 289 is close to a multiple
-    //      of 41 (41*7 = 287)
-    
-    float3 x = 2.0 * fract(p * C.www) - 1.0;
-    float3 h = abs(x) - 0.5;
-    float3 ox = floor(x + 0.5);
-    float3 a0 = x - ox;
-    
-    // Normalise gradients implicitly by scaling m
-    // Approximation of: m *= inversesqrt(a0*a0 + h*h);
-    m *= 1.79284291400159 - 0.85373472095314 * (a0*a0+h*h);
-    
-    // Compute final noise value at P
-    float3 g = float3(0.0);
-    g.x  = a0.x  * x0.x  + h.x  * x0.y;
-    g.yz = a0.yz * float2(x1.x,x2.x) + h.yz * float2(x1.y,x2.y);
-    return 130.0 * dot(m, g);
-}
 
 typedef struct {
     // The [[position]] attribute of this member indicates that this value
@@ -98,19 +22,15 @@ typedef struct {
     // returned from the vertex function.
     float4 position [[position]];
     
-    // Since this member does not have a special attribute, the rasterizer
-    // interpolates its value with the values of the other triangle vertices
-    // and then passes the interpolated value to the fragment shader for each
-    // fragment in the triangle.
-    float4 color [[flat]];
+    // Need the non-transformed position for noise generation
+    float2 colorPosition;
     
-} ColoredVertex;
+} Vertex;
 
 // This function creates color and position data for the vertices from viewport size
-vertex ColoredVertex simplexVertexShader(uint vertexID [[vertex_id]],
-                                        constant float2 *positions [[buffer(SimpleShaderIndexPositions)]],
-                                        constant float4 *colors [[buffer(SimpleShaderIndexColors)]],
-                                        constant float4 *viewport [[buffer(SimpleShaderIndexViewport)]]) {
+vertex Vertex terrainVertexShader(uint vertexID [[vertex_id]],
+                                  constant float2 *positions [[buffer(ShaderIndexPositions)]],
+                                  constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
     float2 pixelSpacePosition = positions[vertexID];
     float2 roundedPixelSpacePosition = round(pixelSpacePosition * 100) / 100;
     float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
@@ -118,29 +38,16 @@ vertex ColoredVertex simplexVertexShader(uint vertexID [[vertex_id]],
     float x = (roundedPixelSpacePosition.x - viewportOrigin.x) / viewportSize.x;
     float y = (roundedPixelSpacePosition.y - viewportOrigin.y) / viewportSize.y;
     
-    ColoredVertex out;
+    Vertex out;
     out.position = float4(x, y, 0.0, 1.0);
-    
-    float2 pos = float2(pixelSpacePosition * 0.00008 * 7.168);
-    float DF = 1.288;
-    
-    // Add a random position
-    float a = .0;
-    float2 vel = float2(0.070,0.140);
-    DF += snoise(pos+vel)*-0.710+0.290;
-    
-    // Add a random position
-    a = snoise(pos*float2(cos(0.958),sin(0.300))*-0.044)*0.029;
-    vel = float2(cos(a),sin(a));
-    DF += snoise(pos+vel)*-0.046+0.378;
-    
-    float3 color = smoothstep(0.260,0.094,fract(DF));
-    
-    out.color = float4(1.0 - color, 1.0);
+    out.colorPosition = positions[vertexID];
     return out;
 }
 
 // Use the defined color to set tile color
-fragment float4 simplexFragmentShader(ColoredVertex in [[stage_in]]) {
-    return in.color;
+fragment float4 terrainFragmentShader(Vertex in [[stage_in]]) {
+    float2 pos = float2(in.colorPosition.xy * 0.001);
+    float3 color = float3(fractalBrownianMotion(pos), fractalBrownianMotion(pos - 2.0), fractalBrownianMotion(pos + 0.1));
+    
+    return float4(color, 1.0);
 }

--- a/metal/Util.h
+++ b/metal/Util.h
@@ -1,0 +1,16 @@
+//
+//  Util.h
+//  Genera
+//
+//  Created by Dylan Gattey on 11/3/20.
+//
+
+// Has all util functions defined (make sure the Util.metal file includes these impls)
+
+#ifndef Util_h
+#define Util_h
+
+float simplexNoise(float2 v);
+float fractalBrownianMotion(float2 uv);
+
+#endif /* Util_h */

--- a/metal/Util.metal
+++ b/metal/Util.metal
@@ -1,0 +1,100 @@
+//
+//  Util.metal
+//  Genera
+//
+//  Created by Dylan Gattey on 11/2/20.
+//
+
+// Has all util functions defined (make sure the Util.h file includes these defs)
+
+#include <metal_stdlib>
+#include <simd/simd.h>
+#include "Util.h"
+
+using namespace metal;
+
+float3 mod289(float3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+float2 mod289(float2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+float3 permute(float3 x) { return mod289(((x*34.0)+1.0)*x); }
+
+//
+// Description : GLSL 2D simplex noise function
+//      Author : Ian McEwan, Ashima Arts
+//  Maintainer : ijm
+//     Lastmod : 20110822 (ijm)
+//     License :
+//  Copyright (C) 2011 Ashima Arts. All rights reserved.
+//  Distributed under the MIT License. See LICENSE file.
+//  https://github.com/ashima/webgl-noise
+//
+float simplexNoise(float2 v) {
+    
+    // Precompute values for skewed triangular grid
+    const float4 C = float4(0.211324865405187,
+                                          // (3.0-sqrt(3.0))/6.0
+                                          0.366025403784439,
+                                          // 0.5*(sqrt(3.0)-1.0)
+                                          -0.577350269189626,
+                                          // -1.0 + 2.0 * C.x
+                                          0.024390243902439);
+                                          // 1.0 / 41.0
+    
+    // First corner (x0)
+    float2 i  = floor(v + dot(v, C.yy));
+    float2 x0 = v - i + dot(i, C.xx);
+    
+    // Other two corners (x1, x2)
+    float2 i1 = float2(0.0);
+    i1 = (x0.x > x0.y)? float2(1.0, 0.0):float2(0.0, 1.0);
+    float2 x1 = x0.xy + C.xx - i1;
+    float2 x2 = x0.xy + C.zz;
+    
+    // Do some permutations to avoid
+    // truncation effects in permutation
+    i = mod289(i);
+    float3 p = permute(
+                     permute( i.y + float3(0.0, i1.y, 1.0))
+                     + i.x + float3(0.0, i1.x, 1.0 ));
+    
+    float3 m = max(0.5 - float3(
+                            dot(x0,x0),
+                            dot(x1,x1),
+                            dot(x2,x2)
+                            ), 0.0);
+    
+    m = m*m ;
+    m = m*m ;
+    
+    // Gradients:
+    //  41 pts uniformly over a line, mapped onto a diamond
+    //  The ring size 17*17 = 289 is close to a multiple
+    //      of 41 (41*7 = 287)
+    
+    float3 x = 2.0 * fract(p * C.www) - 1.0;
+    float3 h = abs(x) - 0.5;
+    float3 ox = floor(x + 0.5);
+    float3 a0 = x - ox;
+    
+    // Normalise gradients implicitly by scaling m
+    // Approximation of: m *= inversesqrt(a0*a0 + h*h);
+    m *= 1.79284291400159 - 0.85373472095314 * (a0*a0+h*h);
+    
+    // Compute final noise value at P
+    float3 g = float3(0.0);
+    g.x  = a0.x  * x0.x  + h.x  * x0.y;
+    g.yz = a0.yz * float2(x1.x,x2.x) + h.yz * float2(x1.y,x2.y);
+    return 130.0 * dot(m, g);
+}
+
+// Uses 4 octaves and 0.7 amp changes
+float fractalBrownianMotion(float2 uv) {
+    float sum = 0;
+    float amp = 0.7;
+    for(int i = 0; i < 4; ++i)
+    {
+        sum += simplexNoise(uv) * amp;
+        uv += uv * 1.2;
+        amp *= 0.4;
+    }
+    return sum;
+}

--- a/utility/Logger.swift
+++ b/utility/Logger.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Simple logger, with config
 enum Logger {
 
-    static let shouldLog = true
+    static let shouldLog = false
 
     /// Logs a value if logging is on
     static func log(_ value: Any) {

--- a/utility/Logger.swift
+++ b/utility/Logger.swift
@@ -1,0 +1,22 @@
+//
+//  Logger.swift
+//  Genera
+//
+//  Created by Dylan Gattey on 11/1/20.
+//
+
+import Foundation
+
+/// Simple logger, with config
+enum Logger {
+
+    static let shouldLog = true
+
+    /// Logs a value if logging is on
+    static func log(_ value: Any) {
+        if (shouldLog) {
+            print(String(describing: value))
+        }
+    }
+
+}

--- a/utility/Logger.swift
+++ b/utility/Logger.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Simple logger, with config
 enum Logger {
 
-    static let shouldLog = false
+    static let shouldLog = true
 
     /// Logs a value if logging is on
     static func log(_ value: Any) {


### PR DESCRIPTION
1. `VertexProtocol` and `GridVertex` and `TerrainVertex` types with better structure for imports from headers & bridging header
1. `BasicGenerator` -> `RandomTileGenerator`, plus generics so that the generator has an associated type (vertex type), which the renderer uses as a generic, which is owned by the coordinator. `Renderer` should never need to be changed! Different generators, following the same structures, should be able to provide enough data to draw. Of course I'll probably be proved wrong.
1. Initial terrain generation with a simplex noise shader implemented (but not called) in `TerrainShaders.metal`
1. Generation is now on an event loop for speed in the `RandomTileGenerator`
1. Logging can be toggled on and off at will in `Logger.swift`