### PR TITLE
feat: presets for terrain generation settings

### DIFF
--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		7528BD4D255522F3008038A3 /* EditableConfigValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7528BD4C255522F3008038A3 /* EditableConfigValue.swift */; };
 		75764D732558CE02000AC3DA /* GameType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D722558CE02000AC3DA /* GameType.swift */; };
 		75764D7B2558F0D7000AC3DA /* TerrainData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D7A2558F0D7000AC3DA /* TerrainData.swift */; };
+		75764D7F2558F270000AC3DA /* TerrainPresetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D7E2558F270000AC3DA /* TerrainPresetView.swift */; };
+		75764D88255900CB000AC3DA /* TerrainPresetLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D87255900CB000AC3DA /* TerrainPresetLoader.swift */; };
+		75764D8B25591903000AC3DA /* TerrainPresetDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D8A25591903000AC3DA /* TerrainPresetDelegate.swift */; };
 		757DF61E254F687F005723D5 /* SwiftPriorityQueue in Frameworks */ = {isa = PBXBuildFile; productRef = 757DF61D254F687F005723D5 /* SwiftPriorityQueue */; };
 		757DF621254F90CB005723D5 /* DebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF620254F90CB005723D5 /* DebugView.swift */; };
 		757DF626254FA0FF005723D5 /* DebugDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF625254FA0FF005723D5 /* DebugDelegate.swift */; };
@@ -87,6 +90,9 @@
 		7528BD4C255522F3008038A3 /* EditableConfigValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableConfigValue.swift; sourceTree = "<group>"; };
 		75764D722558CE02000AC3DA /* GameType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameType.swift; sourceTree = "<group>"; };
 		75764D7A2558F0D7000AC3DA /* TerrainData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TerrainData.swift; sourceTree = "<group>"; };
+		75764D7E2558F270000AC3DA /* TerrainPresetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerrainPresetView.swift; sourceTree = "<group>"; };
+		75764D87255900CB000AC3DA /* TerrainPresetLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerrainPresetLoader.swift; sourceTree = "<group>"; };
+		75764D8A25591903000AC3DA /* TerrainPresetDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerrainPresetDelegate.swift; sourceTree = "<group>"; };
 		757DF620254F90CB005723D5 /* DebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugView.swift; sourceTree = "<group>"; };
 		757DF625254FA0FF005723D5 /* DebugDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDelegate.swift; sourceTree = "<group>"; };
 		757E14E9255151F50036AEB5 /* Color.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Color.metal; sourceTree = "<group>"; };
@@ -189,6 +195,8 @@
 			children = (
 				757DF620254F90CB005723D5 /* DebugView.swift */,
 				7528BCFC255472B4008038A3 /* TerrainConfigView.swift */,
+				75764D8A25591903000AC3DA /* TerrainPresetDelegate.swift */,
+				75764D7E2558F270000AC3DA /* TerrainPresetView.swift */,
 				759EFFFB254DE361004CF89F /* InteractableViewProtocol.swift */,
 				75FA6D3C254C06C600A1B409 /* InteractableMTKView.swift */,
 				7528BD08255489D4008038A3 /* LabeledView.swift */,
@@ -204,6 +212,7 @@
 				7528BD4825551D58008038A3 /* DefaultTerrainData.swift */,
 				757E154F255331290036AEB5 /* TerrainTile.swift */,
 				757E154C2552C0130036AEB5 /* TerrainChunkDataProvider.swift */,
+				75764D87255900CB000AC3DA /* TerrainPresetLoader.swift */,
 			);
 			path = terrainGen;
 			sourceTree = "<group>";
@@ -460,6 +469,7 @@
 				757E152C2552A6EC0036AEB5 /* DatedChunk.swift in Sources */,
 				7528BD44255514E0008038A3 /* BiomeType+Swift.swift in Sources */,
 				75B90875254B796A00231E39 /* GridTile.swift in Sources */,
+				75764D8B25591903000AC3DA /* TerrainPresetDelegate.swift in Sources */,
 				7528BD4D255522F3008038A3 /* EditableConfigValue.swift in Sources */,
 				757E154D2552C0130036AEB5 /* TerrainChunkDataProvider.swift in Sources */,
 				7528BD0C25549013008038A3 /* SidePanelViewController.swift in Sources */,
@@ -470,12 +480,14 @@
 				75FA6D80254D3D7200A1B409 /* ZoomDirection.swift in Sources */,
 				75C4B4B62550062600F36372 /* TerrainShaders.metal in Sources */,
 				75FA6D31254BF07A00A1B409 /* ChunkCoordinatorDelegate.swift in Sources */,
+				75764D7F2558F270000AC3DA /* TerrainPresetView.swift in Sources */,
 				7528BD41255512A1008038A3 /* Biome+Defaults.swift in Sources */,
 				757E15392552AD1A0036AEB5 /* ViewportCoordinatorDelegate.swift in Sources */,
 				75764D7B2558F0D7000AC3DA /* TerrainData.swift in Sources */,
 				757DF621254F90CB005723D5 /* DebugView.swift in Sources */,
 				750379A0254A8538002A0C13 /* GridShaders.metal in Sources */,
 				757E14EA255151F50036AEB5 /* Color.metal in Sources */,
+				75764D88255900CB000AC3DA /* TerrainPresetLoader.swift in Sources */,
 				75B2B764254B71AD00351DC8 /* ChunkCoordinator.swift in Sources */,
 				75D897AC25552C1A00EEDC00 /* ShaderDataProtocol.swift in Sources */,
 				757E15322552A7350036AEB5 /* GridTileChunkDataProvider.swift in Sources */,

--- a/Genera.xcodeproj/project.pbxproj
+++ b/Genera.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		7528BD4925551D58008038A3 /* DefaultTerrainData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7528BD4825551D58008038A3 /* DefaultTerrainData.swift */; };
 		7528BD4D255522F3008038A3 /* EditableConfigValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7528BD4C255522F3008038A3 /* EditableConfigValue.swift */; };
 		75764D732558CE02000AC3DA /* GameType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D722558CE02000AC3DA /* GameType.swift */; };
+		75764D7B2558F0D7000AC3DA /* TerrainData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75764D7A2558F0D7000AC3DA /* TerrainData.swift */; };
 		757DF61E254F687F005723D5 /* SwiftPriorityQueue in Frameworks */ = {isa = PBXBuildFile; productRef = 757DF61D254F687F005723D5 /* SwiftPriorityQueue */; };
 		757DF621254F90CB005723D5 /* DebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF620254F90CB005723D5 /* DebugView.swift */; };
 		757DF626254FA0FF005723D5 /* DebugDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757DF625254FA0FF005723D5 /* DebugDelegate.swift */; };
@@ -85,6 +86,7 @@
 		7528BD4825551D58008038A3 /* DefaultTerrainData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTerrainData.swift; sourceTree = "<group>"; };
 		7528BD4C255522F3008038A3 /* EditableConfigValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableConfigValue.swift; sourceTree = "<group>"; };
 		75764D722558CE02000AC3DA /* GameType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameType.swift; sourceTree = "<group>"; };
+		75764D7A2558F0D7000AC3DA /* TerrainData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TerrainData.swift; sourceTree = "<group>"; };
 		757DF620254F90CB005723D5 /* DebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugView.swift; sourceTree = "<group>"; };
 		757DF625254FA0FF005723D5 /* DebugDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDelegate.swift; sourceTree = "<group>"; };
 		757E14E9255151F50036AEB5 /* Color.metal */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.metal; path = Color.metal; sourceTree = "<group>"; };
@@ -198,6 +200,8 @@
 		7528BD232554EE9B008038A3 /* terrainGen */ = {
 			isa = PBXGroup;
 			children = (
+				75764D7A2558F0D7000AC3DA /* TerrainData.swift */,
+				7528BD4825551D58008038A3 /* DefaultTerrainData.swift */,
 				757E154F255331290036AEB5 /* TerrainTile.swift */,
 				757E154C2552C0130036AEB5 /* TerrainChunkDataProvider.swift */,
 			);
@@ -326,7 +330,6 @@
 				757E151125525B750036AEB5 /* VertexProtocol.swift */,
 				7528BD40255512A1008038A3 /* Biome+Defaults.swift */,
 				7528BD43255514E0008038A3 /* BiomeType+Swift.swift */,
-				7528BD4825551D58008038A3 /* DefaultTerrainData.swift */,
 			);
 			path = data;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				75FA6D31254BF07A00A1B409 /* ChunkCoordinatorDelegate.swift in Sources */,
 				7528BD41255512A1008038A3 /* Biome+Defaults.swift in Sources */,
 				757E15392552AD1A0036AEB5 /* ViewportCoordinatorDelegate.swift in Sources */,
+				75764D7B2558F0D7000AC3DA /* TerrainData.swift in Sources */,
 				757DF621254F90CB005723D5 /* DebugView.swift in Sources */,
 				750379A0254A8538002A0C13 /* GridShaders.metal in Sources */,
 				757E14EA255151F50036AEB5 /* Color.metal in Sources */,

--- a/game/dataProviders/ShaderDataProtocol.swift
+++ b/game/dataProviders/ShaderDataProtocol.swift
@@ -9,18 +9,10 @@ import Foundation
 
 /// Defines a protocol for all config data shared between the shader and swift code conforms to. Exactly
 /// one of these will be sent in MapRenderer to the shader
-protocol ShaderDataProtocol {
-    
-    /// The number of biomes we'll pass to the shader
-    var numBiomes: Int32 { get }
-}
+protocol ShaderDataProtocol {}
 
-/// Used for shaders that don't have configuration data - dummy class
-class EmptyShaderData: ShaderDataProtocol {
-    
-    var numBiomes: Int32 {
-        fatalError("Should not be called ever")
-    }
-}
-
+/// Extends existing shader with the protocol
 extension TerrainShaderConfigData: ShaderDataProtocol {}
+
+/// Empty class for use when I have no data to pass to the shader
+class EmptyShaderData: ShaderDataProtocol {}

--- a/game/terrainGen/DefaultTerrainData.swift
+++ b/game/terrainGen/DefaultTerrainData.swift
@@ -10,6 +10,13 @@ import Foundation
 /// Contains a bunch of different default data to use elsewhere
 enum DefaultTerrainData {
     
+    /// The name of the preset representing this set of defaults
+    static let presetName = "Default Settings"
+    
+    /// The identifer of the preset representing this set of defaults
+    static let presetID = "com.dgattey.genera.default"
+    
+    /// The value that sets the map gen seed
     static let seed: String = "puppy"
     
     /// In the shader, this scales all coordinates

--- a/game/terrainGen/DefaultTerrainData.swift
+++ b/game/terrainGen/DefaultTerrainData.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-/// Contains a bunch of different default data to use elsewhere
+/// In-memory fallback for default terrain data if it doesn't exist locally
 enum DefaultTerrainData {
     
     /// The name of the preset representing this set of defaults
     static let presetName = "Default Settings"
     
     /// The identifer of the preset representing this set of defaults
-    static let presetID = "com.dgattey.genera.default"
+    static let presetID = "defaultSettings"
     
     /// The value that sets the map gen seed
     static let seed: String = "puppy"
@@ -35,7 +35,7 @@ enum DefaultTerrainData {
     static let moistureDistribution: Float = 0.9
     
     /// Defaults for FBMData for elevation noise generation
-    static let elevationFMB = FBMData(
+    static let elevationFBM = FBMData(
         octaves: 11,
         persistence: 0.55,
         scale: 0.01,
@@ -43,7 +43,7 @@ enum DefaultTerrainData {
         seed: 0)
     
     /// Defaults for FBMData for moisture noise generation
-    static let moistureFMB = FBMData(
+    static let moistureFBM = FBMData(
         octaves: 9,
         persistence: 0.6,
         scale: 0.03,
@@ -55,5 +55,22 @@ enum DefaultTerrainData {
     
     /// Default amount to weight moisture in color generation [0-1]
     static let moistureColorWeight: Float = 0.0
+    
+    /// So we can save this to disk if we need to
+    static var terrainData: TerrainData {
+        TerrainData(
+            presetName: presetName,
+            presetID: presetID,
+            seed: seed,
+            globalScalar: globalScalar,
+            seaLevelOffset: seaLevelOffset,
+            elevationDistribution: elevationDistribution,
+            aridness: aridness,
+            moistureDistribution: moistureDistribution,
+            elevationFBM: elevationFBM,
+            moistureFBM: moistureFBM,
+            elevationColorWeight: elevationColorWeight,
+            moistureColorWeight: moistureColorWeight)
+    }
 
 }

--- a/game/terrainGen/TerrainData.swift
+++ b/game/terrainGen/TerrainData.swift
@@ -35,10 +35,10 @@ struct TerrainData: Codable {
     let moistureDistribution: Float
     
     /// Defaults for FBMData for elevation noise generation
-    let elevationFMB: FBMData
+    let elevationFBM: FBMData
     
     /// Defaults for FBMData for moisture noise generation
-    let moistureFMB: FBMData
+    let moistureFBM: FBMData
     
     /// Default amount to weight elevation in color generation [0-1]
     let elevationColorWeight: Float

--- a/game/terrainGen/TerrainData.swift
+++ b/game/terrainGen/TerrainData.swift
@@ -1,0 +1,82 @@
+//
+//  TerrainData.swift
+//  Genera
+//
+//  Created by Dylan Gattey on 11/8/20.
+//
+
+import Foundation
+
+/// Class for data for terrain generation used to create presets. Mirrors static properties in DefaultTerrainData
+struct TerrainData: Codable {
+    
+    /// The name of the preset representing this set of defaults
+    let presetName: String
+    
+    /// The identifer of the preset representing this set of defaults
+    let presetID: String
+    
+    /// The value that sets the map gen seed
+    let seed: String
+    
+    /// In the shader, this scales all coordinates
+    let globalScalar: Float
+    
+    /// The offset from 0 the sea level should have
+    let seaLevelOffset: Float
+    
+    /// How spiky the elevation should be (higher values create higher peaks/flatter valleys)
+    let elevationDistribution: Float
+    
+    /// The offset from 0 the moisture level should have
+    let aridness: Float
+    
+    /// How spiky/distributed the moisture should be (higher values create more extremes)
+    let moistureDistribution: Float
+    
+    /// Defaults for FBMData for elevation noise generation
+    let elevationFMB: FBMData
+    
+    /// Defaults for FBMData for moisture noise generation
+    let moistureFMB: FBMData
+    
+    /// Default amount to weight elevation in color generation [0-1]
+    let elevationColorWeight: Float
+    
+    /// Default amount to weight moisture in color generation [0-1]
+    let moistureColorWeight: Float
+
+}
+
+// MARK: - FBMData Codable
+
+/// This is defined in .h file so putting it here for conformance
+extension FBMData: Codable {
+    
+    enum CodingKeys: String, CodingKey {
+        case octaves
+        case persistence
+        case scale
+        case compression
+        case seed
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(octaves, forKey: .octaves)
+        try container.encode(persistence, forKey: .persistence)
+        try container.encode(scale, forKey: .scale)
+        try container.encode(compression, forKey: .compression)
+        try container.encode(seed, forKey: .seed)
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let octaves = try values.decode(Int32.self, forKey: .octaves)
+        let persistence = try values.decode(Float.self, forKey: .persistence)
+        let scale = try values.decode(Float.self, forKey: .scale)
+        let compression = try values.decode(Float.self, forKey: .compression)
+        let seed = try values.decode(UInt32.self, forKey: .seed)
+        self.init(octaves: octaves, persistence: persistence, scale: scale, compression: compression, seed: seed)
+    }
+}

--- a/game/terrainGen/TerrainPresetLoader.swift
+++ b/game/terrainGen/TerrainPresetLoader.swift
@@ -1,0 +1,95 @@
+//
+//  TerrainPresetLoader.swift
+//  Genera
+//
+//  Created by Dylan Gattey on 11/8/20.
+//
+
+import Foundation
+
+/// Loads and saves terrain presets to disk
+enum TerrainPresetLoader {
+    
+    /// The type of file we save
+    private static let fileExtension = "json"
+    
+    /// Name of the folder where presets are stored
+    private static var presetsFolderName = "generaPresets"
+    
+    /// The URL for the presets folder (in containers)
+    static var presetsFolderURL: URL {
+        let documentsFolder = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return documentsFolder.appendingPathComponent(presetsFolderName)
+    }
+    
+    /// Easier way to grab the path itself for the presets folder
+    static var presetsFolderPath: String {
+        return presetsFolderURL.path
+    }
+    
+    /// Location of default presets - will get created if they don't exist
+    private static var defaultPresetsPath: String {
+        return presetsFolderURL.appendingPathComponent(DefaultTerrainData.presetID).appendingPathExtension(fileExtension).path
+    }
+    
+    /// Creates the presets folder itself if it's missing
+    private static func createPresetsFolderIfNonexistent() {
+        if !FileManager.default.fileExists(atPath: presetsFolderPath) {
+            do {
+                try FileManager.default.createDirectory(atPath: presetsFolderPath, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                Logger.log("Problem creating presets folder: \(error.localizedDescription)")
+            }
+        }
+        // Save default preset too if missing
+        if !FileManager.default.fileExists(atPath: defaultPresetsPath) {
+            savePreset(DefaultTerrainData.terrainData)
+        }
+    }
+    
+    /// Saves the given preset to disk in the presets folder
+    static func savePreset(_ preset: TerrainData, onCompletion: ((_ presetName: String) -> Void)? = nil) {
+        DispatchQueue.global(qos: .utility).async {
+            createPresetsFolderIfNonexistent()
+            let encoder = JSONEncoder()
+            guard let data = try? encoder.encode(preset) else {
+                Logger.log("Couldn't create data")
+                return
+            }
+            let path = presetsFolderURL.appendingPathComponent(preset.presetID).appendingPathExtension(fileExtension).path
+            FileManager.default.createFile(atPath: path, contents: data, attributes: nil)
+            onCompletion?(preset.presetName)
+        }
+    }
+    
+    /// Loads all plists in the presets folder to try converting them - doesn't run from a background queue
+    static func loadPresets() -> [TerrainData] {
+        createPresetsFolderIfNonexistent()
+        let decoder = JSONDecoder()
+
+        var terrainDataArray: [TerrainData] = []
+        guard let enumerator = FileManager.default.enumerator(at: presetsFolderURL,
+                                                              includingPropertiesForKeys: [.isRegularFileKey],
+                                                              options: [.skipsPackageDescendants, .skipsHiddenFiles],
+                                                              errorHandler: nil) else {
+            return terrainDataArray
+        }
+        
+        // Try decoding each file recursively in the subdirectory
+        for case let fileURL as URL in enumerator {
+            guard let fileAttributes = try? fileURL.resourceValues(forKeys:[.isRegularFileKey]),
+               fileAttributes.isRegularFile ?? false else {
+                // Not a real file
+                continue
+            }
+            if let fileData = try? Data.init(contentsOf: fileURL),
+               let terrainData = try? decoder.decode(TerrainData.self, from: fileData) {
+                terrainDataArray.append(terrainData)
+            } else {
+                Logger.log("Didn't convert \(fileURL) to a valid preset")
+            }
+        }
+        return terrainDataArray
+    }
+
+}

--- a/macOS/AppDelegate.swift
+++ b/macOS/AppDelegate.swift
@@ -13,6 +13,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
     }
+    
+    /// Used in prompting for replies
+    typealias PromptResponseClosure = (_ value: String, _ success: Bool) -> Void
+    
+    /// Used from anywhere to prompt for a reply
+    static func promptForReply(from window: NSWindow,
+                               withTitle title: String,
+                               details: String,
+                               placeholder: String,
+                               completion: @escaping PromptResponseClosure) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.buttons.first?.bezelColor = .red
+        alert.addButton(withTitle: "Cancel")
+        alert.messageText = title
+        alert.informativeText = details
+        
+        let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 32))
+        textField.bezelStyle = .roundedBezel
+        textField.isAutomaticTextCompletionEnabled = true
+        textField.isSelectable = true
+        textField.maximumNumberOfLines = 6
+        textField.lineBreakMode = .byCharWrapping
+        textField.usesSingleLineMode = false
+        textField.placeholderString = placeholder
+        textField.stringValue = ""
+        
+        alert.accessoryView = textField
+        alert.beginSheetModal(for: window) { response in
+            switch response {
+            case .alertFirstButtonReturn:
+                completion(textField.stringValue, true)
+            default:
+                completion(textField.stringValue, false)
+            }
+        }
+    }
 
 }
 

--- a/macOS/editableConfig/EditableConfigValue.swift
+++ b/macOS/editableConfig/EditableConfigValue.swift
@@ -124,6 +124,28 @@ class EditableConfigValue<T: LosslessStringConvertible>: NSObject, NSTextFieldDe
     
     // MARK: - API
     
+    /// Updates the current value to a given value in both the stepper and field itself, and updates the delegate
+    func changeValue(to value: Any) {
+        switch valueType {
+        case .decimalNumber:
+            let previous = field.floatValue
+            field.formatter = floatFormatter // in case it's not currently set
+            field.stringValue = String(describing: value)
+            stepper?.floatValue = field.floatValue
+            updateDelegate?.configDidUpdate(from: previous, to: field.floatValue)
+        case .wholeNumber:
+            let previous = field.integerValue
+            field.stringValue = String(describing: value)
+            stepper?.intValue = field.intValue
+            updateDelegate?.configDidUpdate(from: previous, to: field.integerValue)
+        case .string:
+            let previous = field.stringValue
+            field.stringValue = String(describing: value)
+            stepper?.stringValue = field.stringValue
+            updateDelegate?.configDidUpdate(from: previous, to: field.stringValue)
+        }
+    }
+    
     /// Called from the NSStepper to update the text field
     @objc func updateValue() {
         guard let stepper = stepper else {
@@ -140,7 +162,7 @@ class EditableConfigValue<T: LosslessStringConvertible>: NSObject, NSTextFieldDe
             let previous = field.integerValue
             field.integerValue = stepper.integerValue
             updateDelegate?.configDidUpdate(from: previous, to: field.integerValue)
-        default:
+        case .string:
             assertionFailure("Strings should not have steppers")
         }
     }

--- a/macOS/editableConfig/EditableFBMConfigValues.swift
+++ b/macOS/editableConfig/EditableFBMConfigValues.swift
@@ -40,4 +40,22 @@ class EditableFBMConfigValues {
         EditableValuesStackView.addValue(stackView)(scale)
         EditableValuesStackView.addValue(stackView)(compression)
     }
+    
+    /// Changes current values to new values from the data passed in
+    func changeValues(to values: FBMData) {
+        octaves.changeValue(to: values.octaves)
+        persistence.changeValue(to: values.persistence)
+        scale.changeValue(to: values.scale)
+        compression.changeValue(to: values.compression)
+    }
+    
+    /// Creates FBMData from all fields with a provided seed
+    func value(withSeed seed: uint) -> FBMData {
+        return FBMData(
+            octaves: octaves.value,
+            persistence: persistence.value,
+            scale: scale.value,
+            compression: compression.value,
+            seed: seed)
+    }
 }

--- a/macOS/editableConfig/EditableValuesStackView.swift
+++ b/macOS/editableConfig/EditableValuesStackView.swift
@@ -34,6 +34,7 @@ class EditableValuesStackView: NSStackView {
     func addValue<T>(_ value: EditableConfigValue<T>) {
         value.field.delegate = value
         let stack = NSStackView()
+        stack.distribution = .fill
         LabeledView.addView(value.field, labeledWith: value.label, toStack: stack)
         
         // Make sure to setup the stepper and its action properly

--- a/macOS/views/LabeledView.swift
+++ b/macOS/views/LabeledView.swift
@@ -61,6 +61,8 @@ enum LabeledView {
         let string = NSAttributedString(string: text, attributes: attributes)
         let field = NSTextField(labelWithAttributedString: string)
         field.drawsBackground = false
+        field.allowsEditingTextAttributes = true
+        field.isSelectable = true
         return field
     }
     

--- a/macOS/views/TerrainConfigView.swift
+++ b/macOS/views/TerrainConfigView.swift
@@ -15,14 +15,15 @@ class TerrainConfigView: NSStackView {
     /// Update delegate, needs to be set for ALLLL the values. This is tedious
     weak var updateDelegate: ConfigUpdateDelegate? {
         didSet {
-            moistureValues.updateDelegate = updateDelegate
             seed.updateDelegate = updateDelegate
             globalScalar.updateDelegate = updateDelegate
-            elevationValues.updateDelegate = updateDelegate
+            
+            elevationFBM.updateDelegate = updateDelegate
             seaLevelOffset.updateDelegate = updateDelegate
             elevationDistribution.updateDelegate = updateDelegate
             elevationColorWeight.updateDelegate = updateDelegate
-            moistureValues.updateDelegate = updateDelegate
+            
+            moistureFBM.updateDelegate = updateDelegate
             aridness.updateDelegate = updateDelegate
             moistureDistribution.updateDelegate = updateDelegate
             moistureColorWeight.updateDelegate = updateDelegate
@@ -39,8 +40,8 @@ class TerrainConfigView: NSStackView {
         fallback: DefaultTerrainData.globalScalar,
         label: "Global scalar")
     
-    /// FMB values for elevation noise generation
-    private let elevationValues = EditableFBMConfigValues(defaultData: DefaultTerrainData.elevationFMB)
+    /// FBM values for elevation noise generation
+    private let elevationFBM = EditableFBMConfigValues(defaultData: DefaultTerrainData.elevationFBM)
     
     /// As a float, how far off of zero we should make sea level
     private let seaLevelOffset = EditableConfigValue(
@@ -57,8 +58,8 @@ class TerrainConfigView: NSStackView {
         fallback: DefaultTerrainData.elevationColorWeight,
         label: "Color weight")
     
-    /// FMB values for moisture noise generation
-    private let moistureValues = EditableFBMConfigValues(defaultData: DefaultTerrainData.moistureFMB)
+    /// FBM values for moisture noise generation
+    private let moistureFBM = EditableFBMConfigValues(defaultData: DefaultTerrainData.moistureFBM)
     
     /// How dry "default" is on the map
     private let aridness = EditableConfigValue(
@@ -100,14 +101,14 @@ class TerrainConfigView: NSStackView {
         addView(sharedView)
         
         let elevationView = EditableValuesStackView(title: "Elevation Config")
-        elevationValues.addValues(to: elevationView)
+        elevationFBM.addValues(to: elevationView)
         elevationView.addValue(seaLevelOffset)
         elevationView.addValue(elevationDistribution)
         elevationView.addValue(elevationColorWeight)
         addView(elevationView)
         
         let moistureView = EditableValuesStackView(title: "Moisture Config")
-        moistureValues.addValues(to: moistureView)
+        moistureFBM.addValues(to: moistureView)
         moistureView.addValue(aridness)
         moistureView.addValue(moistureDistribution)
         moistureView.addValue(moistureColorWeight)
@@ -124,16 +125,16 @@ extension TerrainConfigView: ShaderDataProviderProtocol {
     /// Config data for generation of noise, pulls data from text fields if they exist
     var configData: TerrainShaderConfigData {
         let elevationGenerator = FBMData(
-            octaves: elevationValues.octaves.value,
-            persistence: elevationValues.persistence.value,
-            scale: elevationValues.scale.value,
-            compression: elevationValues.compression.value,
+            octaves: elevationFBM.octaves.value,
+            persistence: elevationFBM.persistence.value,
+            scale: elevationFBM.scale.value,
+            compression: elevationFBM.compression.value,
             seed: Self.seed(from: seed.value))
         let moistureGenerator = FBMData(
-            octaves: moistureValues.octaves.value,
-            persistence: moistureValues.persistence.value,
-            scale: moistureValues.scale.value,
-            compression: moistureValues.compression.value,
+            octaves: moistureFBM.octaves.value,
+            persistence: moistureFBM.persistence.value,
+            scale: moistureFBM.scale.value,
+            compression: moistureFBM.compression.value,
             seed: Self.seed(from: seed.value))
         return TerrainShaderConfigData(
             numBiomes: Int32(allBiomes.count),

--- a/macOS/views/TerrainConfigView.swift
+++ b/macOS/views/TerrainConfigView.swift
@@ -95,6 +95,11 @@ class TerrainConfigView: NSStackView {
         distribution = .fill
         spacing = SidePanelViewController.interItemSpacing
         
+        let presetView = TerrainPresetView(title: "Presets")
+        presetView.presetDelegate = self
+        presetView.populatePresets()
+        addView(presetView)
+        
         let sharedView = EditableValuesStackView(title: "Global Config")
         sharedView.addValue(seed)
         sharedView.addValue(globalScalar)
@@ -152,6 +157,46 @@ extension TerrainConfigView: ShaderDataProviderProtocol {
     /// Bunch of biomes with different elevation and moistures
     var allBiomes: [Biome] {
         return Biome.defaultBiomes
+    }
+    
+}
+
+// MARK: - TerrainPresetDelegate
+
+extension TerrainConfigView: TerrainPresetDelegate {
+    
+    /// Called when the user selects the given preset to change all values
+    func selectPreset(_ preset: TerrainData) {
+        seed.changeValue(to: preset.seed)
+        globalScalar.changeValue(to: preset.globalScalar)
+        
+        elevationFBM.changeValues(to: preset.elevationFBM)
+        seaLevelOffset.changeValue(to: preset.seaLevelOffset)
+        elevationDistribution.changeValue(to: preset.elevationDistribution)
+        elevationColorWeight.changeValue(to: preset.elevationColorWeight)
+        
+        moistureFBM.changeValues(to: preset.moistureFBM)
+        aridness.changeValue(to: preset.aridness)
+        moistureDistribution.changeValue(to: preset.moistureDistribution)
+        moistureColorWeight.changeValue(to: preset.moistureColorWeight)
+    }
+    
+    /// Called when the user wants to save the current data as a preset
+    func saveCurrentDataAsPreset(named name: String, onCompletion: @escaping (_ presetName: String) -> Void) {
+        let preset = TerrainData(
+            presetName: name,
+            presetID: "customPreset-\(name.decomposedStringWithCanonicalMapping)",
+            seed: seed.value,
+            globalScalar: globalScalar.value,
+            seaLevelOffset: seaLevelOffset.value,
+            elevationDistribution: elevationDistribution.value,
+            aridness: aridness.value,
+            moistureDistribution: moistureDistribution.value,
+            elevationFBM: elevationFBM.value(withSeed: Self.seed(from: seed.value)),
+            moistureFBM: moistureFBM.value(withSeed: Self.seed(from: seed.value)),
+            elevationColorWeight: elevationColorWeight.value,
+            moistureColorWeight: moistureColorWeight.value)
+        TerrainPresetLoader.savePreset(preset, onCompletion: onCompletion)
     }
     
 }

--- a/macOS/views/TerrainConfigView.swift
+++ b/macOS/views/TerrainConfigView.swift
@@ -10,6 +10,8 @@ import AppKit
 /// A stack view containing text fields for certain configurable data
 class TerrainConfigView: NSStackView {
     
+    // MARK: - variables
+    
     /// Update delegate, needs to be set for ALLLL the values. This is tedious
     weak var updateDelegate: ConfigUpdateDelegate? {
         didSet {
@@ -27,34 +29,53 @@ class TerrainConfigView: NSStackView {
         }
     }
     
+    /// Seed for generation of the map (string)
     private let seed = EditableConfigValue(
         fallback: DefaultTerrainData.seed,
         label: "Terrain seed")
+    
+    /// Scaling constant for all coordinates on the map
     private let globalScalar = EditableConfigValue(
         fallback: DefaultTerrainData.globalScalar,
         label: "Global scalar")
     
+    /// FMB values for elevation noise generation
     private let elevationValues = EditableFBMConfigValues(defaultData: DefaultTerrainData.elevationFMB)
+    
+    /// As a float, how far off of zero we should make sea level
     private let seaLevelOffset = EditableConfigValue(
         fallback: DefaultTerrainData.seaLevelOffset,
         label: "Sea level offset")
+    
+    /// The distribution of values (spiky or not) for elevation
     private let elevationDistribution = EditableConfigValue(
         fallback: DefaultTerrainData.elevationDistribution,
         label: "Elevation distribution")
+    
+    /// How much elevation contributes to color of the biome
     private let elevationColorWeight = EditableConfigValue(
         fallback: DefaultTerrainData.elevationColorWeight,
         label: "Color weight")
     
+    /// FMB values for moisture noise generation
     private let moistureValues = EditableFBMConfigValues(defaultData: DefaultTerrainData.moistureFMB)
+    
+    /// How dry "default" is on the map
     private let aridness = EditableConfigValue(
         fallback: DefaultTerrainData.aridness,
         label: "Aridness")
+    
+    /// The distribution of values (spiky or not) for moisture
     private let moistureDistribution = EditableConfigValue(
         fallback: DefaultTerrainData.moistureDistribution,
         label: "Moisture distribution")
+    
+    /// How much moisture contributes to color of the biome
     private let moistureColorWeight = EditableConfigValue(
         fallback: DefaultTerrainData.moistureColorWeight,
         label: "Color weight")
+    
+    // MARK: - API
     
     /// Adds a nested stack view with equal widths
     private func addView(_ view: EditableValuesStackView) {

--- a/macOS/views/TerrainPresetDelegate.swift
+++ b/macOS/views/TerrainPresetDelegate.swift
@@ -1,0 +1,19 @@
+//
+//  TerrainPresetDelegate.swift
+//  Genera
+//
+//  Created by Dylan Gattey on 11/8/20.
+//
+
+import Foundation
+
+/// Things the terrain preset view alerts about
+protocol TerrainPresetDelegate: class {
+    
+    /// Called when the user selects the given preset
+    func selectPreset(_ preset: TerrainData)
+    
+    /// Called when the user wants to save the current data as a preset, with a callback function
+    func saveCurrentDataAsPreset(named name: String, onCompletion: @escaping (_ presetName: String) -> Void)
+
+}

--- a/macOS/views/TerrainPresetView.swift
+++ b/macOS/views/TerrainPresetView.swift
@@ -1,0 +1,146 @@
+//
+//  TerrainPresetView.swift
+//  Genera
+//
+//  Created by Dylan Gattey on 11/8/20.
+//
+
+import AppKit
+
+/// Allows choosing different preset values for terrain that you can save and load at runtime
+class TerrainPresetView: EditableValuesStackView {
+    
+    // MARK: - variables
+    
+    /// Collects preset name -> preset data groupings
+    private var presets: [String: TerrainData] = [:]
+    
+    /// Called when things happen in the presets
+    weak var presetDelegate: TerrainPresetDelegate?
+    
+    /// Allows choosing between different preset values as the fallback
+    private lazy var presetChooser: NSPopUpButton = {
+        let button = NSPopUpButton()
+        button.target = self
+        button.action = #selector(selectPreset)
+        return button
+    }()
+    
+    /// Exposes a button to save current settings
+    private lazy var saveButton: NSButton = {
+        let button = NSButton()
+        button.setButtonType(.momentaryPushIn)
+        button.bezelStyle = .rounded
+        button.title = "Save Current Settings"
+        button.target = self
+        button.action = #selector(savePreset)
+        button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return button
+    }()
+    
+    /// Reloads the presets from disk
+    private lazy var reloadButton: NSButton = {
+        let reloadButton = NSButton()
+        reloadButton.setButtonType(.momentaryPushIn)
+        reloadButton.bezelStyle = .rounded
+        reloadButton.title = "Reload"
+        reloadButton.target = self
+        reloadButton.action = #selector(reloadPresets)
+        reloadButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return reloadButton
+    }()
+    
+    /// Opens the Finder folder where the presets live
+    private lazy var openButton: NSButton = {
+        let button = NSButton()
+        button.setButtonType(.momentaryPushIn)
+        button.bezelStyle = .rounded
+        button.title = "Open folder"
+        button.target = self
+        button.action = #selector(openPresetsFolder)
+        return button
+    }()
+    
+    // MARK: - API
+    
+    /// Adds the correct views + reload presets to start with from disk
+    func populatePresets() {
+        reloadPresets()
+        
+        // The chooser itself
+        let presetChooserStack = NSStackView()
+        presetChooserStack.distribution = .fill
+        presetChooserStack.addView(presetChooser, in: .leading)
+        presetChooserStack.addView(saveButton, in: .trailing)
+        addView(presetChooserStack, in: .bottom)
+        
+        // Helper text + buttons to open presets folder + reset
+        LabeledView.addLabel("Presets located at:\n\(TerrainPresetLoader.presetsFolderPath)", style: .field, toStack: self)
+        let buttonsStack = NSStackView()
+        buttonsStack.distribution = .fill
+        buttonsStack.addView(openButton, in: .leading)
+        buttonsStack.addView(reloadButton, in: .trailing)
+        addView(buttonsStack, in: .bottom)
+    }
+    
+    /// Reloads all presets into the main array onto a background thread, then reloads the preset chooser
+    @objc func reloadPresets() {
+        reloadPresetsAndReset(bySelecting: DefaultTerrainData.presetName)
+    }
+    
+    /// Opens the presets folder in Finder
+    @objc func openPresetsFolder() {
+        NSWorkspace.shared.openFile(TerrainPresetLoader.presetsFolderPath)
+    }
+    
+    /// Selects a given preset from the list
+    @objc func selectPreset(_ sender: AnyObject?) {
+        if let popupButton = sender as? NSPopUpButton,
+           let menuItem = popupButton.selectedItem,
+           let preset = presets[menuItem.title] {
+            print("Did select \(preset)")
+            presetDelegate?.selectPreset(preset)
+        }
+    }
+    
+    /// Delegates to save the current settings as a new preset
+    @objc func savePreset(_ sender: AnyObject?) {
+        guard let window = window else {
+            assertionFailure("Missing window")
+            return
+        }
+        AppDelegate.promptForReply(from: window,
+                                   withTitle: "Save as...",
+                                   details: "Name your preset to finish saving it",
+                                   placeholder: "My Favorite Map") { (name, success) in
+            guard success else {
+                return
+            }
+            self.presetDelegate?.saveCurrentDataAsPreset(named: name, onCompletion: { [weak self] presetName in
+                self?.reloadPresetsAndReset(bySelecting: presetName)
+            })
+        }
+        
+    }
+    
+    // MARK: - private helpers
+    
+    /// Reloads all presets into the main array onto a background thread, then reloads the preset chooser
+    private func reloadPresetsAndReset(bySelecting presetName: String) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let presets = TerrainPresetLoader.loadPresets()
+            let keys = presets.map({ $0.presetName })
+            self?.presets = Dictionary(uniqueKeysWithValues: zip(keys, presets))
+            DispatchQueue.main.async {
+                guard let strongSelf = self else {
+                    return
+                }
+                let keys = Array(strongSelf.presets.keys).sorted()
+                strongSelf.presetChooser.removeAllItems()
+                strongSelf.presetChooser.addItems(withTitles: keys)
+                strongSelf.presetChooser.selectItem(withTitle: presetName)
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
Allows saving and loading of presets to the default container folder in the app! Super easy and clean. You can name them or not, and there's a default one that gets created (and selected) if it doesn't exist.

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/982182/98514442-4d872d80-221e-11eb-8511-76fdcb99c384.png">