### PR TITLE
fix: a bunch of bugs around viewports and pixel density and dragging

### DIFF
--- a/src/Debug/Sources/Debug/DebugDataType.swift
+++ b/src/Debug/Sources/Debug/DebugDataType.swift
@@ -19,4 +19,7 @@ public enum DebugDataType: String {
 
     /// The current window's viewport itself
     case windowViewport = "Window viewport"
+
+    /// Viewport buffer data to pass to GPU
+    case viewportBufferData = "Viewport Buffer Data"
 }

--- a/src/Engine/Sources/Engine/GameCoordinator.swift
+++ b/src/Engine/Sources/Engine/GameCoordinator.swift
@@ -36,6 +36,7 @@ public class GameCoordinator<ChunkDataProvider: ChunkDataProviderProtocol> {
         didSet {
             chunkCoordinator.debugger = debugger
             viewportCoordinator.debugger = debugger
+            renderer.debugger = debugger
         }
     }
 

--- a/src/Engine/Sources/Engine/MapRenderer.swift
+++ b/src/Engine/Sources/Engine/MapRenderer.swift
@@ -117,13 +117,13 @@ class MapRenderer<ChunkDataProvider: ChunkDataProviderProtocol,
 
     /// Makes sure bytes are stored for the new user position viewport
     private func updateUserViewportBufferData(to viewport: MTLViewport) {
+        drawingSemaphore.signal()
         viewportBufferData = [Float(viewport.originX),
                               Float(viewport.originY),
                               Float(viewport.width),
                               Float(viewport.height)]
-        view
-            .setNeedsDisplay(NSRect(x: viewport.originX, y: viewport.originY, width: viewport.width,
-                                    height: viewport.height))
+        view.setNeedsDisplay(view.bounds)
+        _ = drawingSemaphore.wait(timeout: DispatchTime.distantFuture)
     }
 
     /// Draws the shapes as specified in all our chunked buffers (will loop over all chunks)

--- a/src/Engine/Sources/Engine/MapRenderer.swift
+++ b/src/Engine/Sources/Engine/MapRenderer.swift
@@ -66,7 +66,8 @@ class MapRenderer<ChunkDataProvider: ChunkDataProviderProtocol,
 
         mainDevice = device
         self.view = view
-        viewportBufferData = ViewportData(origin: view.bounds.origin, size: view.bounds.size, scaleFactor: CGSize(width: 1, height: 1))
+        let scaleFactor = view.drawableSize / view.bounds.size
+        viewportBufferData = ViewportData(origin: view.bounds.origin, size: view.bounds.size, scaleFactor: scaleFactor)
         self.commandQueue = commandQueue
         self.renderPipelineState = renderPipelineState
         self.dataProvider = dataProvider
@@ -117,10 +118,12 @@ class MapRenderer<ChunkDataProvider: ChunkDataProviderProtocol,
         _ = drawingSemaphore.wait(timeout: DispatchTime.distantFuture)
     }
 
-    /// Makes sure bytes are stored for the new user position viewport
+    /// Makes sure bytes are stored for the new user position viewport, scaling by the view's scale factor so we're
+    /// drawing the same thing consistently on any screen
     private func updateUserViewportBufferData(to viewport: MTLViewport) {
         drawingSemaphore.signal()
-        viewportBufferData = ViewportData(viewport, scaleFactor: CGSize(width: 1, height: 1))
+        let scaleFactor = view.drawableSize / view.bounds.size
+        viewportBufferData = ViewportData(viewport, scaleFactor: scaleFactor)
         view.setNeedsDisplay(view.bounds)
         _ = drawingSemaphore.wait(timeout: DispatchTime.distantFuture)
     }

--- a/src/Engine/Sources/Engine/MapRenderer.swift
+++ b/src/Engine/Sources/Engine/MapRenderer.swift
@@ -15,6 +15,7 @@ class MapRenderer<ChunkDataProvider: ChunkDataProviderProtocol,
 
     weak var userInteractionDelegate: UserInteractionDelegate?
     weak var viewportDataProvider: ViewportDataProvider?
+    weak var debugger: DebugProtocol?
 
     // MARK: - variables
 
@@ -120,10 +121,11 @@ class MapRenderer<ChunkDataProvider: ChunkDataProviderProtocol,
 
     /// Makes sure bytes are stored for the new user position viewport, scaling by the view's scale factor so we're
     /// drawing the same thing consistently on any screen
-    private func updateUserViewportBufferData(to viewport: MTLViewport) {
+    private func updateUserViewportBufferData(to viewport: MTLViewport, inDrawableSize drawableSize: CGSize) {
         drawingSemaphore.signal()
-        let scaleFactor = view.drawableSize / view.bounds.size
+        let scaleFactor = drawableSize / view.bounds.size
         viewportBufferData = ViewportData(viewport, scaleFactor: scaleFactor)
+        debugger?.subject(for: .viewportBufferData).send(viewportBufferData)
         view.setNeedsDisplay(view.bounds)
         _ = drawingSemaphore.wait(timeout: DispatchTime.distantFuture)
     }
@@ -266,8 +268,8 @@ extension MapRenderer: ChunkCoordinatorDelegate {
 
 extension MapRenderer: ViewportCoordinatorDelegate {
     /// Updates viewport buffer data with the new viewport info
-    func viewportCoordinator(didUpdateUserPositionTo viewport: MTLViewport) {
-        updateUserViewportBufferData(to: viewport)
+    func viewportCoordinator(didUpdateUserPositionTo viewport: MTLViewport, inDrawableSize drawableSize: CGSize) {
+        updateUserViewportBufferData(to: viewport, inDrawableSize: drawableSize)
     }
 
     /// Forwards to the chunk coordinator

--- a/src/Engine/Sources/Engine/Viewport/CGPoint+Swift.swift
+++ b/src/Engine/Sources/Engine/Viewport/CGPoint+Swift.swift
@@ -1,0 +1,91 @@
+// CGPoint+Swift.swift
+// Copyright (c) 2020 Dylan Gattey
+
+import Foundation
+
+/// Allows for arithmetic on the CGPoint itself
+public extension CGPoint {
+    // MARK: - CGPoint & CGPoint
+
+    /// Adds two points together and returns the new point
+    static func + (left: CGPoint, right: CGPoint) -> CGPoint {
+        CGPoint(x: left.x + right.x, y: left.y + right.y)
+    }
+
+    /// Adds the second point to the first
+    static func += (left: inout CGPoint, right: CGPoint) {
+        left = left + right
+    }
+
+    /// Subtracts the second from the first and returns the new point
+    static func - (left: CGPoint, right: CGPoint) -> CGPoint {
+        CGPoint(x: left.x - right.x, y: left.y - right.y)
+    }
+
+    /// Subtracts the second from the first
+    static func -= (left: inout CGPoint, right: CGPoint) {
+        left = left - right
+    }
+
+    /// Multiplies two points together and returns the new point
+    static func * (left: CGPoint, right: CGPoint) -> CGPoint {
+        CGPoint(x: left.x * right.x, y: left.y * right.y)
+    }
+
+    /// Multiplies the second point with the first
+    static func *= (left: inout CGPoint, right: CGPoint) {
+        left = left * right
+    }
+
+    /// Divides the first point by the second and returns the new point
+    static func / (left: CGPoint, right: CGPoint) -> CGPoint {
+        CGPoint(x: left.x / right.x, y: left.y / right.y)
+    }
+
+    /// Divides the first point by the second
+    static func /= (left: inout CGPoint, right: CGPoint) {
+        left = left / right
+    }
+
+    // MARK: - CGPoint & CGSize
+
+    /// Adds a size and a point together
+    static func + (left: CGPoint, right: CGSize) -> CGPoint {
+        CGPoint(x: left.x + right.width, y: left.y + right.height)
+    }
+
+    /// Adds the size to an existing point
+    static func += (left: inout CGPoint, right: CGSize) {
+        left = left + right
+    }
+
+    /// Returns a point with size subtracted from it
+    static func - (left: CGPoint, right: CGSize) -> CGPoint {
+        CGPoint(x: left.x - right.width, y: left.y - right.height)
+    }
+
+    /// Subtracts the size from the point
+    static func -= (left: inout CGPoint, right: CGSize) {
+        left = left - right
+    }
+
+    /// Returns a point with size multiplied by it
+    static func * (left: CGPoint, right: CGSize) -> CGPoint {
+        CGPoint(x: left.x * right.width, y: left.y * right.height)
+    }
+
+    /// Multiplies the point by a size
+    static func *= (left: inout CGPoint, right: CGSize) {
+        left = left * right
+    }
+
+    /// Returns a point divided by size
+    static func / (left: CGPoint, right: CGSize) -> CGPoint {
+        CGPoint(x: left.x / right.width, y: left.y / right.height)
+    }
+
+    /// Divides the point by size
+    static func /= (left: inout CGPoint, right: CGSize) {
+        left = left / right
+    }
+}

--- a/src/Engine/Sources/Engine/Viewport/CGSize+Swift.swift
+++ b/src/Engine/Sources/Engine/Viewport/CGSize+Swift.swift
@@ -1,0 +1,47 @@
+// CGSize+Swift.swift
+// Copyright (c) 2020 Dylan Gattey
+
+import Foundation
+
+/// Allows for arithmetic on the CGSize itself
+public extension CGSize {
+    /// Adds two sizes together and returns a new size
+    static func + (left: CGSize, right: CGSize) -> CGSize {
+        CGSize(width: left.width + right.width, height: left.height + right.height)
+    }
+
+    /// Adds the second size to the first and returns the first
+    static func += (left: inout CGSize, right: CGSize) {
+        left = left + right
+    }
+
+    /// Subtracts the second from the first and returns a new size
+    static func - (left: CGSize, right: CGSize) -> CGSize {
+        CGSize(width: left.width - right.width, height: left.height - right.height)
+    }
+
+    /// Subtracts the second size to the first and returns the first
+    static func -= (left: inout CGSize, right: CGSize) {
+        left = left - right
+    }
+
+    /// Multiples the second by the first and returns a new size
+    static func * (left: CGSize, right: CGSize) -> CGSize {
+        CGSize(width: left.width * right.width, height: left.height * right.height)
+    }
+
+    /// Multiples the second by the first and returns the first
+    static func *= (left: inout CGSize, right: CGSize) {
+        left = left * right
+    }
+
+    /// Divides the second by the first and returns a new size
+    static func / (left: CGSize, right: CGSize) -> CGSize {
+        CGSize(width: left.width / right.width, height: left.height / right.height)
+    }
+
+    /// Divides the second by the first and returns the first
+    static func /= (left: inout CGSize, right: CGSize) {
+        left = left / right
+    }
+}

--- a/src/Engine/Sources/Engine/Viewport/UserInteractionDelegate.swift
+++ b/src/Engine/Sources/Engine/Viewport/UserInteractionDelegate.swift
@@ -11,6 +11,6 @@ public protocol UserInteractionDelegate: NSObject {
     /// Called in response to resizing of the viewport to a new size
     func userDidResizeViewport(to size: CGSize) -> Void
 
-    /// Called in response to a zoom of the viewport in a given direction at a point onscreen
-    func userDidZoomViewport(_ direction: ZoomDirection, at point: NSPoint) -> Void
+    /// Called in response to a zoom of the viewport in a given direction at a point onscreen within a given size
+    func userDidZoomViewport(_ direction: ZoomDirection, at point: NSPoint, withinSize size: CGSize) -> Void
 }

--- a/src/Engine/Sources/Engine/Viewport/ViewportCoordinator.swift
+++ b/src/Engine/Sources/Engine/Viewport/ViewportCoordinator.swift
@@ -198,9 +198,8 @@ class ViewportCoordinator<DataProvider: ChunkDataProviderProtocol>: NSObject, Vi
         currentZoomLevel = max(ViewportCoordinatorConstant.ZoomLevel.min, min(ViewportCoordinatorConstant.ZoomLevel.max, currentZoomLevel * changeAmount))
 
         // Convert the screen point (0,0 in lower left) to Metal space (0,0 in center)
-        // TODO: @dgattey this assumes pixel density of screen is 2x, figure out how to find that.
-        let normX = 4 * Double(point.x) - currentViewport.width
-        let normY = 4 * Double(point.y) - currentViewport.height
+        let normX = 2 * Double(point.x) - currentViewport.width
+        let normY = 2 * Double(point.y) - currentViewport.height
 
         // Change the origin based on where we're zooming into
         let originDeltaX = normX * prevZoom - normX * currentZoomLevel

--- a/src/Engine/Sources/Engine/Viewport/ViewportCoordinatorDelegate.swift
+++ b/src/Engine/Sources/Engine/Viewport/ViewportCoordinatorDelegate.swift
@@ -6,8 +6,8 @@ import Metal
 
 /// A delegate for changes that occur in the viewport
 protocol ViewportCoordinatorDelegate: NSObject {
-    /// Called when the user position has changed to a new viewport
-    func viewportCoordinator(didUpdateUserPositionTo viewport: MTLViewport) -> Void
+    /// Called when the user position has changed to a new viewport within a drawable size
+    func viewportCoordinator(didUpdateUserPositionTo viewport: MTLViewport, inDrawableSize size: CGSize) -> Void
 
     /// Called when the visible region gets updated
     func viewportCoordinator(didUpdateVisibleRegionTo: (x: Range<Int>, y: Range<Int>)) -> Void

--- a/src/Engine/Sources/Engine/Viewport/ViewportData+Swift.swift
+++ b/src/Engine/Sources/Engine/Viewport/ViewportData+Swift.swift
@@ -1,0 +1,22 @@
+// ViewportData+Swift.swift
+// Copyright (c) 2020 Dylan Gattey
+
+import Foundation
+import Metal
+
+/// Allows for convenience initializers for ViewportData
+extension ViewportData {
+    /// Creates a viewport data with an MTLViewport, and its scale
+    init(_ viewport: MTLViewport, scaleFactor: CGSize) {
+        self.init(origin: vector_float2(Float(viewport.originX), Float(viewport.originY)),
+                  size: vector_float2(Float(viewport.width), Float(viewport.height)),
+                  scaleFactor: vector_float2(Float(scaleFactor.width), Float(scaleFactor.height)))
+    }
+
+    /// Creates a viewport data with CG constructs
+    init(origin: CGPoint, size: CGSize, scaleFactor: CGSize) {
+        self.init(origin: vector_float2(Float(origin.x), Float(origin.y)),
+                  size: vector_float2(Float(size.width), Float(size.height)),
+                  scaleFactor: vector_float2(Float(scaleFactor.width), Float(scaleFactor.height)))
+    }
+}

--- a/src/Engine/Sources/EngineData/include/ViewportData.h
+++ b/src/Engine/Sources/EngineData/include/ViewportData.h
@@ -1,0 +1,22 @@
+// ViewportData.h
+// Copyright (c) 2020 Dylan Gattey
+
+#ifndef ViewportData_h
+#define ViewportData_h
+
+#import <simd/simd.h>
+
+/// A struct of data representing everything we need to represent the viewport
+struct ViewportData {
+    
+    /// Origin of the viewport (x, y)
+    vector_float2 origin;
+    
+    /// Size of the viewport (width, height)
+    vector_float2 size;
+    
+    /// How much to scale the viewport by in xy directions - used as a proxy for pixel density
+    vector_float2 scaleFactor;
+};
+
+#endif /* ViewportData_h */

--- a/src/EngineUI/Sources/EngineUI/InteractableMTKView.swift
+++ b/src/EngineUI/Sources/EngineUI/InteractableMTKView.swift
@@ -82,11 +82,10 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
             return
         }
         let amount = Double(event.scrollingDeltaY)
-
-        // Figures out if we're currently at pixel density of 2 or 1 (Retina vs. regular)
-        let scaleFactor = drawableSize / bounds.size
         let convertedPoint = convert(event.locationInWindow, from: windowView)
-        userInteractionDelegate?.userDidZoomViewport(ZoomDirection(amount), at: convertedPoint * scaleFactor)
+        userInteractionDelegate?.userDidZoomViewport(ZoomDirection(amount),
+                                                     at: convertedPoint,
+                                                     withinSize: bounds.size)
     }
 
     /// If the key is a direction, add it to our array and start panning in that direction

--- a/src/EngineUI/Sources/EngineUI/InteractableMTKView.swift
+++ b/src/EngineUI/Sources/EngineUI/InteractableMTKView.swift
@@ -14,10 +14,10 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
     private static let eventLoopLength: DispatchQueue.SchedulerTimeType.Stride = .milliseconds(5)
 
     /// How much the mouse has to drag for it to be considered a pan in any direction
-    private static let mouseMoveThreshold: CGFloat = 1.0
+    private static let mouseMoveThreshold: CGFloat = 0.25
 
     /// Scales mouse move values to make them cleaner
-    private static let mouseMoveScalar: Double = 0.15
+    private static let mouseMoveScalar: Double = 0.25
 
     /// Converts a key press event into a direction using key code
     private static func direction(fromKeyPressEvent event: NSEvent) -> VectoredDirection<Double>? {
@@ -58,18 +58,6 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
 
     /// Runs the processer for pans to notify the viewport
     private var panViewEventLoop: Cancellable?
-
-    /// Makes sure we can zooms and key presses
-    override public var acceptsFirstResponder: Bool {
-        true
-    }
-
-    /// Make sure mouse down doesn't move the window so we can drag around
-    override public var mouseDownCanMoveWindow: Bool {
-        false
-    }
-
-    // MARK: - initialization
 
     // MARK: - handle events
 
@@ -121,6 +109,11 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
 
     /// Figure out which direction we're dragging in and pan that way
     override public func mouseDragged(with event: NSEvent) {
+        // If the click is outside the effective bounds of this view (outside the content layout rect)
+        // then we don't want to allow it to do anything
+        guard window?.contentLayoutRect.contains(event.locationInWindow) ?? false else {
+            return
+        }
         mouseDirections = InteractableMTKView.directions(fromMouseEvent: event)
         guard !mouseDirections.isEmpty else {
             // We're not panning enough to matter in any direction, so cancel the event loop if no key presses

--- a/src/EngineUI/Sources/EngineUI/InteractableMTKView.swift
+++ b/src/EngineUI/Sources/EngineUI/InteractableMTKView.swift
@@ -76,11 +76,17 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
     /// Use the y axis's scrolling delta to zoom the viewport in or out
     override public func scrollWheel(with event: NSEvent) {
         // Trackpad is changed phase, mouse wheel is empty phase
-        guard event.phase == .changed || event.phase == [] else {
+        guard event.phase == .changed || event.phase == [],
+              let windowView = window?.contentView
+        else {
             return
         }
         let amount = Double(event.scrollingDeltaY)
-        userInteractionDelegate?.userDidZoomViewport(ZoomDirection(amount), at: event.locationInWindow)
+
+        // Figures out if we're currently at pixel density of 2 or 1 (Retina vs. regular)
+        let scaleFactor = drawableSize / bounds.size
+        let convertedPoint = convert(event.locationInWindow, from: windowView)
+        userInteractionDelegate?.userDidZoomViewport(ZoomDirection(amount), at: convertedPoint * scaleFactor)
     }
 
     /// If the key is a direction, add it to our array and start panning in that direction
@@ -93,11 +99,9 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
         // Insert the direction, and start the event loop for panning if needed
         keyPressDirections.insert(direction)
         if panViewEventLoop == nil {
-            panViewEventLoop = DispatchQueue.main.schedule(
-                after: DispatchQueue.SchedulerTimeType(.now()),
-                interval: InteractableMTKView.eventLoopLength,
-                panView
-            )
+            panViewEventLoop = DispatchQueue.main.schedule(after: DispatchQueue.SchedulerTimeType(.now()),
+                                                           interval: InteractableMTKView.eventLoopLength,
+                                                           panView)
         }
     }
 
@@ -130,11 +134,9 @@ public class InteractableMTKView: MTKView, InteractableViewProtocol {
 
         // Start the event loop for panning if needed
         if panViewEventLoop == nil {
-            panViewEventLoop = DispatchQueue.main.schedule(
-                after: DispatchQueue.SchedulerTimeType(.now()),
-                interval: InteractableMTKView.eventLoopLength,
-                panView
-            )
+            panViewEventLoop = DispatchQueue.main.schedule(after: DispatchQueue.SchedulerTimeType(.now()),
+                                                           interval: InteractableMTKView.eventLoopLength,
+                                                           panView)
         }
     }
 

--- a/src/MacOS/Base.lproj/Main.storyboard
+++ b/src/MacOS/Base.lproj/Main.storyboard
@@ -335,7 +335,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="800" height="600"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </view>
-                        <toolbar key="toolbar" implicitIdentifier="C8EBF028-1B18-4A8E-91F7-D3136539DFEA" autosavesConfiguration="NO" allowsUserCustomization="NO" displayMode="iconOnly" sizeMode="regular" id="Jul-at-Bb0">
+                        <toolbar key="toolbar" implicitIdentifier="C8EBF028-1B18-4A8E-91F7-D3136539DFEA" allowsUserCustomization="NO" displayMode="iconOnly" sizeMode="regular" id="Jul-at-Bb0">
                             <allowedToolbarItems/>
                             <defaultToolbarItems/>
                             <connections>

--- a/src/Shaders - Game/GridShaders.metal
+++ b/src/Shaders - Game/GridShaders.metal
@@ -5,6 +5,7 @@
 
 #import <metal_stdlib>
 #import <simd/simd.h>
+#import "ViewportData.h" // map renderer (engine), shaders
 #import "GridShaderTypes.h" // Move into folder with this file
 #import "SimplexNoise.h" // here, and all shaders (sharing between here and SimplexNoise is difficult)
 #import "ShaderIndex.h" // map renderer (engine), shaders
@@ -31,15 +32,13 @@ typedef struct {
 // This function creates color and position data for the vertices from viewport size
 vertex FragmentVertex gridVertexShader(uint vertexID [[vertex_id]],
                                        const device GridVertex *vertexArray [[buffer(ShaderIndexVertices)]],
-                                       constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
+                                       const device ViewportData *viewport [[buffer(ShaderIndexViewport)]]) {
     float2 position = vertexArray[vertexID].position;
     
     // Calculate with viewport applied
     float2 roundedPixelSpacePosition = round(position * 100) / 100;
-    float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
-    float2 viewportSize = float2((*viewport).z, (*viewport).w);
-    float x = (roundedPixelSpacePosition.x - viewportOrigin.x) / viewportSize.x;
-    float y = (roundedPixelSpacePosition.y - viewportOrigin.y) / viewportSize.y;
+    float x = (roundedPixelSpacePosition.x - (*viewport).origin.x) / (*viewport).size.x / (*viewport).scaleFactor.x;
+    float y = (roundedPixelSpacePosition.y - (*viewport).origin.y) / (*viewport).size.y / (*viewport).scaleFactor.y;
     
     FragmentVertex out;
     out.position = vector_float4(x, y, 0.0, 1.0);

--- a/src/Shaders - Game/GridShaders.metal
+++ b/src/Shaders - Game/GridShaders.metal
@@ -37,8 +37,8 @@ vertex FragmentVertex gridVertexShader(uint vertexID [[vertex_id]],
     
     // Calculate with viewport applied
     float2 roundedPixelSpacePosition = round(position * 100) / 100;
-    float x = (roundedPixelSpacePosition.x - (*viewport).origin.x) / (*viewport).size.x / (*viewport).scaleFactor.x;
-    float y = (roundedPixelSpacePosition.y - (*viewport).origin.y) / (*viewport).size.y / (*viewport).scaleFactor.y;
+    float x = (roundedPixelSpacePosition.x - (*viewport).origin.x) / (*viewport).size.x * (*viewport).scaleFactor.x;
+    float y = (roundedPixelSpacePosition.y - (*viewport).origin.y) / (*viewport).size.y * (*viewport).scaleFactor.y;
     
     FragmentVertex out;
     out.position = vector_float4(x, y, 0.0, 1.0);

--- a/src/Shaders - Game/TerrainShaders.metal
+++ b/src/Shaders - Game/TerrainShaders.metal
@@ -32,8 +32,8 @@ vertex FragmentVertex terrainVertexShader(uint vertexID [[vertex_id]],
     float2 position = vertexArray[vertexID].position;
     
     // Calculate with viewport applied (translate into 0-2) range
-    float x = (position.x - (*viewport).origin.x) / (*viewport).size.x / (*viewport).scaleFactor.x;
-    float y = (position.y - (*viewport).origin.y) / (*viewport).size.y / (*viewport).scaleFactor.y;
+    float x = (position.x - (*viewport).origin.x) / (*viewport).size.x * (*viewport).scaleFactor.x;
+    float y = (position.y - (*viewport).origin.y) / (*viewport).size.y * (*viewport).scaleFactor.y;
     
     FragmentVertex out;
     out.position = float4(x, y, 0.0, 1.0);

--- a/src/Shaders - Game/TerrainShaders.metal
+++ b/src/Shaders - Game/TerrainShaders.metal
@@ -5,6 +5,7 @@
 
 #import <metal_stdlib>
 #import <simd/simd.h>
+#import "ViewportData.h" // map renderer (engine), shaders
 #import "TerrainShaderTypes.h" // Move into folder with this file
 #import "TerrainShaderConfigData.h" // Shared with GeneraGame (TerrainConfigView), and here
 #import "SimplexNoise.h" // here, and all shaders (sharing between here and SimplexNoise is difficult)
@@ -27,14 +28,12 @@ typedef struct {
 // This function creates color position and clip space postion data for the vertices from viewport size
 vertex FragmentVertex terrainVertexShader(uint vertexID [[vertex_id]],
                                           const device TerrainVertex *vertexArray [[buffer(ShaderIndexVertices)]],
-                                          constant float4 *viewport [[buffer(ShaderIndexViewport)]]) {
+                                          const device ViewportData *viewport [[buffer(ShaderIndexViewport)]]) {
     float2 position = vertexArray[vertexID].position;
     
     // Calculate with viewport applied (translate into 0-2) range
-    float2 viewportOrigin = float2((*viewport).x, (*viewport).y);
-    float2 viewportSize = float2((*viewport).z, (*viewport).w);
-    float x = (position.x - viewportOrigin.x) / viewportSize.x;
-    float y = (position.y - viewportOrigin.y) / viewportSize.y;
+    float x = (position.x - (*viewport).origin.x) / (*viewport).size.x / (*viewport).scaleFactor.x;
+    float y = (position.y - (*viewport).origin.y) / (*viewport).size.y / (*viewport).scaleFactor.y;
     
     FragmentVertex out;
     out.position = float4(x, y, 0.0, 1.0);


### PR DESCRIPTION
1. Zooming was broken on non-Retina displays because the scaling of the origin delta was off by a factor of pixel density
2. Swapping displays zoomed the map itself by the pixel density (half of it visible on external display that was non-Retina)
3. Presets app menu would disappear if you clicked terrain game type multiple times
4. [Developer happiness bug 😄] Viewport data was just an array of floats instead of structured data
5. Dragging the titlebar area both moved the map and the window with disastrous effects when moving windows between displays
6. It wasn't obvious that the titlebar area was draggable

Creative fixes to all this - basically involved using pixel density in a few places, including new struct for ViewportData. Titlebar is fixed with a new to me API, `NSTrackingArea` + `contentLayoutRect` and some fun animations of a dummy view to make it visually obvious. Didn't realize you could get the size of the view without the toolbar, but it's a nice API to use! Also adds convenience methods for math with `CGSize`s and `CGPoint`s