### PR TITLE
fix: get rid of build warnings + update copyright

### DIFF
--- a/BuildTools/Empty.swift
+++ b/BuildTools/Empty.swift
@@ -1,3 +1,3 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // As packages have to contain at least one Swift file, this is what we got
 import Foundation

--- a/BuildTools/Package.resolved
+++ b/BuildTools/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "SwiftFormat",
-        "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
-        "state": {
-          "branch": null,
-          "revision": "70f5cf51fed37f847556bb28d9d267675f337402",
-          "version": "0.47.3"
-        }
+  "pins" : [
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/SwiftFormat",
+      "state" : {
+        "revision" : "c7ddb09c3381cff833106345721fc314dba49e20",
+        "version" : "0.49.18"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/BuildTools/Package.swift
+++ b/BuildTools/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 import PackageDescription
 
 /// This package incldues SwiftFormat so we can run linting and formatting
@@ -6,7 +6,7 @@ let buildToolsPackage = Package(
     name: "BuildTools",
     platforms: [.macOS(.v11)],
     dependencies: [
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.47.3"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.49.18"),
     ],
     targets: [
         .target(name: "BuildTools", path: "", exclude: ["format-swift.zsh"]),

--- a/Genera.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Genera.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/nicklockwood/SwiftFormat",
         "state": {
           "branch": null,
-          "revision": "70f5cf51fed37f847556bb28d9d267675f337402",
-          "version": "0.47.3"
+          "revision": "c7ddb09c3381cff833106345721fc314dba49e20",
+          "version": "0.49.18"
         }
       },
       {

--- a/src/Debug/Package.swift
+++ b/src/Debug/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/src/Debug/Sources/Debug/DebugDataType.swift
+++ b/src/Debug/Sources/Debug/DebugDataType.swift
@@ -1,5 +1,5 @@
 // DebugDataType.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Debug/Sources/Debug/DebugProtocol.swift
+++ b/src/Debug/Sources/Debug/DebugProtocol.swift
@@ -1,5 +1,5 @@
 // DebugProtocol.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 

--- a/src/Debug/Sources/Debug/Logger.swift
+++ b/src/Debug/Sources/Debug/Logger.swift
@@ -1,5 +1,5 @@
 // Logger.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Package.swift
+++ b/src/Engine/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/src/Engine/Sources/Engine/Chunk/ChunkCoordinator.swift
+++ b/src/Engine/Sources/Engine/Chunk/ChunkCoordinator.swift
@@ -1,5 +1,5 @@
 // ChunkCoordinator.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import Debug

--- a/src/Engine/Sources/Engine/Chunk/ChunkDataProtocol.swift
+++ b/src/Engine/Sources/Engine/Chunk/ChunkDataProtocol.swift
@@ -1,5 +1,5 @@
 // ChunkDataProtocol.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import simd
 

--- a/src/Engine/Sources/Engine/Chunk/ChunkDataProviderProtocol.swift
+++ b/src/Engine/Sources/Engine/Chunk/ChunkDataProviderProtocol.swift
@@ -1,5 +1,5 @@
 // ChunkDataProviderProtocol.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineCore
 import Foundation

--- a/src/Engine/Sources/Engine/Chunk/CountedChunk.swift
+++ b/src/Engine/Sources/Engine/Chunk/CountedChunk.swift
@@ -1,5 +1,5 @@
 // CountedChunk.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineCore
 import Foundation

--- a/src/Engine/Sources/Engine/Chunk/DatedChunk.swift
+++ b/src/Engine/Sources/Engine/Chunk/DatedChunk.swift
@@ -1,5 +1,5 @@
 // DatedChunk.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineCore
 import Foundation

--- a/src/Engine/Sources/Engine/Data Providers/ShaderDataProtocol.swift
+++ b/src/Engine/Sources/Engine/Data Providers/ShaderDataProtocol.swift
@@ -1,5 +1,5 @@
 // ShaderDataProtocol.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/Engine/Data Providers/ShaderDataProviderProtocol.swift
+++ b/src/Engine/Sources/Engine/Data Providers/ShaderDataProviderProtocol.swift
@@ -1,5 +1,5 @@
 // ShaderDataProviderProtocol.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import EngineCore

--- a/src/Engine/Sources/Engine/Data Providers/VertexProtocol.swift
+++ b/src/Engine/Sources/Engine/Data Providers/VertexProtocol.swift
@@ -1,5 +1,5 @@
 // VertexProtocol.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import simd
 

--- a/src/Engine/Sources/Engine/Exports.swift
+++ b/src/Engine/Sources/Engine/Exports.swift
@@ -1,5 +1,5 @@
 // Exports.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/Engine/GameCoordinator.swift
+++ b/src/Engine/Sources/Engine/GameCoordinator.swift
@@ -1,5 +1,5 @@
 // GameCoordinator.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import Debug

--- a/src/Engine/Sources/Engine/MapRenderer.swift
+++ b/src/Engine/Sources/Engine/MapRenderer.swift
@@ -1,5 +1,5 @@
 // MapRenderer.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import Debug

--- a/src/Engine/Sources/Engine/RendererAction.swift
+++ b/src/Engine/Sources/Engine/RendererAction.swift
@@ -1,5 +1,5 @@
 // RendererAction.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 import Metal

--- a/src/Engine/Sources/Engine/Viewport/CGPoint+Swift.swift
+++ b/src/Engine/Sources/Engine/Viewport/CGPoint+Swift.swift
@@ -1,5 +1,5 @@
 // CGPoint+Swift.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/Engine/Viewport/CGSize+Swift.swift
+++ b/src/Engine/Sources/Engine/Viewport/CGSize+Swift.swift
@@ -1,5 +1,5 @@
 // CGSize+Swift.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/Engine/Viewport/ViewportCoordinator.swift
+++ b/src/Engine/Sources/Engine/Viewport/ViewportCoordinator.swift
@@ -1,5 +1,5 @@
 // ViewportCoordinator.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import Debug

--- a/src/Engine/Sources/Engine/Viewport/ViewportData+Swift.swift
+++ b/src/Engine/Sources/Engine/Viewport/ViewportData+Swift.swift
@@ -1,5 +1,5 @@
 // ViewportData+Swift.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineData
 import Foundation

--- a/src/Engine/Sources/Engine/Viewport/ViewportDataProvider.swift
+++ b/src/Engine/Sources/Engine/Viewport/ViewportDataProvider.swift
@@ -1,5 +1,5 @@
 // ViewportDataProvider.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineCore
 import Metal

--- a/src/Engine/Sources/EngineCore/Actions/ViewportAction.swift
+++ b/src/Engine/Sources/EngineCore/Actions/ViewportAction.swift
@@ -1,5 +1,5 @@
 // ViewportAction.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 import Metal

--- a/src/Engine/Sources/EngineCore/Chunk.swift
+++ b/src/Engine/Sources/EngineCore/Chunk.swift
@@ -1,5 +1,5 @@
 // Chunk.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/EngineCore/Codable/Biome+Codable.swift
+++ b/src/Engine/Sources/EngineCore/Codable/Biome+Codable.swift
@@ -1,5 +1,5 @@
 // Biome+Codable.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineData
 import Foundation

--- a/src/Engine/Sources/EngineCore/Codable/BiomeType+Codable.swift
+++ b/src/Engine/Sources/EngineCore/Codable/BiomeType+Codable.swift
@@ -1,5 +1,5 @@
 // BiomeType+Codable.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineData
 import Foundation

--- a/src/Engine/Sources/EngineCore/Codable/FBMData+Codable.swift
+++ b/src/Engine/Sources/EngineCore/Codable/FBMData+Codable.swift
@@ -1,5 +1,5 @@
 // FBMData+Codable.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import EngineData
 import Foundation

--- a/src/Engine/Sources/EngineCore/Directions/Direction.swift
+++ b/src/Engine/Sources/EngineCore/Directions/Direction.swift
@@ -1,5 +1,5 @@
 // Direction.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/EngineCore/Directions/VectoredDirection.swift
+++ b/src/Engine/Sources/EngineCore/Directions/VectoredDirection.swift
@@ -1,5 +1,5 @@
 // VectoredDirection.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/EngineCore/Directions/ZoomDirection.swift
+++ b/src/Engine/Sources/EngineCore/Directions/ZoomDirection.swift
@@ -1,5 +1,5 @@
 // ZoomDirection.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/EngineUI/Biomes/Biome+NSColor.swift
+++ b/src/Engine/Sources/EngineUI/Biomes/Biome+NSColor.swift
@@ -1,5 +1,5 @@
 // Biome+NSColor.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import EngineData

--- a/src/Engine/Sources/EngineUI/Biomes/BiomeOverview.swift
+++ b/src/Engine/Sources/EngineUI/Biomes/BiomeOverview.swift
@@ -1,5 +1,5 @@
 // BiomeOverview.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/Engine/Sources/EngineUI/Editable Values/EditableBiomeValue.swift
+++ b/src/Engine/Sources/EngineUI/Editable Values/EditableBiomeValue.swift
@@ -1,5 +1,5 @@
 // EditableBiomeValue.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/Engine/Sources/EngineUI/Editable Values/EditableBiomeValues.swift
+++ b/src/Engine/Sources/EngineUI/Editable Values/EditableBiomeValues.swift
@@ -1,5 +1,5 @@
 // EditableBiomeValues.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import EngineCore
@@ -11,7 +11,7 @@ import UI
 public class EditableBiomeValues {
     /// Sorts all biomes by moisture and elevation so they draw right
     private static func sortedBiomes(_ biomes: [Biome]) -> [Biome] {
-        biomes.sorted { (a, b) -> Bool in
+        biomes.sorted { a, b -> Bool in
             a.maxMoisture < b.maxMoisture
                 && a.maxElevation - a.minElevation < b.maxElevation - b.minElevation
         }

--- a/src/Engine/Sources/EngineUI/Editable Values/EditableConfigAction.swift
+++ b/src/Engine/Sources/EngineUI/Editable Values/EditableConfigAction.swift
@@ -1,5 +1,5 @@
 // EditableConfigAction.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/Engine/Sources/EngineUI/Editable Values/EditableConfigValue.swift
+++ b/src/Engine/Sources/EngineUI/Editable Values/EditableConfigValue.swift
@@ -1,5 +1,5 @@
 // EditableConfigValue.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/Engine/Sources/EngineUI/Editable Values/EditableFBMConfigValues.swift
+++ b/src/Engine/Sources/EngineUI/Editable Values/EditableFBMConfigValues.swift
@@ -1,5 +1,5 @@
 // EditableFBMConfigValues.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import EngineCore

--- a/src/Engine/Sources/EngineUI/Editable Values/EditableValuesStackView.swift
+++ b/src/Engine/Sources/EngineUI/Editable Values/EditableValuesStackView.swift
@@ -1,5 +1,5 @@
 // EditableValuesStackView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import UI

--- a/src/Engine/Sources/EngineUI/InteractableMTKView.swift
+++ b/src/Engine/Sources/EngineUI/InteractableMTKView.swift
@@ -1,5 +1,5 @@
 // InteractableMTKView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/GeneraGame/Package.swift
+++ b/src/GeneraGame/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/src/GeneraGame/Sources/GeneraGame/Biome+Defaults.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Biome+Defaults.swift
@@ -1,5 +1,5 @@
 // Biome+Defaults.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/GeneraGame/Sources/GeneraGame/Exports.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Exports.swift
@@ -1,5 +1,5 @@
 // Exports.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/GeneraGame/Sources/GeneraGame/GameType.swift
+++ b/src/GeneraGame/Sources/GeneraGame/GameType.swift
@@ -1,5 +1,5 @@
 // GameType.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Foundation
 

--- a/src/GeneraGame/Sources/GeneraGame/GameViewController.swift
+++ b/src/GeneraGame/Sources/GeneraGame/GameViewController.swift
@@ -1,5 +1,5 @@
 // GameViewController.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/GeneraGame/Sources/GeneraGame/Grid/GridTile.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Grid/GridTile.swift
@@ -1,5 +1,5 @@
 // GridTile.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 import simd

--- a/src/GeneraGame/Sources/GeneraGame/Grid/GridTileChunkDataProvider.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Grid/GridTileChunkDataProvider.swift
@@ -1,5 +1,5 @@
 // GridTileChunkDataProvider.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 import Foundation

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/Config + Shader Data/TerrainConfigView.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/Config + Shader Data/TerrainConfigView.swift
@@ -1,5 +1,5 @@
 // TerrainConfigView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/Config + Shader Data/TerrainShaderConfigData+Swift.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/Config + Shader Data/TerrainShaderConfigData+Swift.swift
@@ -1,5 +1,5 @@
 // TerrainShaderConfigData+Swift.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 import Foundation

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/Presets/TerrainPresetData.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/Presets/TerrainPresetData.swift
@@ -1,5 +1,5 @@
 // TerrainPresetData.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 import Foundation

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/Presets/TerrainPresetLoader.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/Presets/TerrainPresetLoader.swift
@@ -1,5 +1,5 @@
 // TerrainPresetLoader.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Combine
 import Debug

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/Presets/TerrainPresetView.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/Presets/TerrainPresetView.swift
@@ -1,5 +1,5 @@
 // TerrainPresetView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/TerrainChunkDataProvider.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/TerrainChunkDataProvider.swift
@@ -1,5 +1,5 @@
 // TerrainChunkDataProvider.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 import Foundation

--- a/src/GeneraGame/Sources/GeneraGame/Terrain/TerrainTile.swift
+++ b/src/GeneraGame/Sources/GeneraGame/Terrain/TerrainTile.swift
@@ -1,5 +1,5 @@
 // TerrainTile.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 import simd

--- a/src/GeneraGame/Sources/GeneraGame/VertexProtocol+Extensions.swift
+++ b/src/GeneraGame/Sources/GeneraGame/VertexProtocol+Extensions.swift
@@ -1,5 +1,5 @@
 // VertexProtocol+Extensions.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import Engine
 

--- a/src/MacOS/AppDelegate.swift
+++ b/src/MacOS/AppDelegate.swift
@@ -1,5 +1,5 @@
 // AppDelegate.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 

--- a/src/MacOS/AppViewController.swift
+++ b/src/MacOS/AppViewController.swift
@@ -1,5 +1,5 @@
 // AppViewController.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 

--- a/src/MacOS/DebugView.swift
+++ b/src/MacOS/DebugView.swift
@@ -1,5 +1,5 @@
 // DebugView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/MacOS/GeneraWindowController.swift
+++ b/src/MacOS/GeneraWindowController.swift
@@ -1,5 +1,5 @@
 // GeneraWindowController.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import GeneraGame

--- a/src/MacOS/HideableTitlebarView.swift
+++ b/src/MacOS/HideableTitlebarView.swift
@@ -1,5 +1,5 @@
 // HideableTitlebarView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Combine

--- a/src/MacOS/SidePanelViewController.swift
+++ b/src/MacOS/SidePanelViewController.swift
@@ -1,5 +1,5 @@
 // SidePanelViewController.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 import Debug

--- a/src/Shaders - Game/TerrainShaders.metal
+++ b/src/Shaders - Game/TerrainShaders.metal
@@ -55,11 +55,7 @@ float4 color(Biome biome, float noise, float weight) {
 float4 blend(Biome upperBiome, Biome lowerBiome, float elevation, float moisture, constant TerrainShaderConfigData *configData) {
     float4 elevationColorA = color(upperBiome, elevation, (*configData).elevationColorWeight);
     float4 elevationColorB = color(lowerBiome, elevation, (*configData).elevationColorWeight);
-    float4 moistureColorA = color(upperBiome, moisture, (*configData).moistureColorWeight);
-    float4 moistureColorB = color(lowerBiome, moisture, (*configData).moistureColorWeight);
     float percentOfElevationThreshold = (upperBiome.minElevation - elevation + upperBiome.blendRange)/upperBiome.blendRange - 0.5 * upperBiome.blendRange;
-    /// TODO: @dgattey is this right at all?
-    float percentOfMoistureThreshold = (upperBiome.maxMoisture - moisture + upperBiome.blendRange)/upperBiome.blendRange - 0.5 * upperBiome.blendRange;
     return mix(elevationColorA, elevationColorB, max(min(percentOfElevationThreshold, 1.0), 0.0));
 }
 

--- a/src/UI/Package.swift
+++ b/src/UI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/src/UI/Sources/UI/LabeledView.swift
+++ b/src/UI/Sources/UI/LabeledView.swift
@@ -1,5 +1,5 @@
 // LabeledView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 

--- a/src/UI/Sources/UI/ScrollableStackView.swift
+++ b/src/UI/Sources/UI/ScrollableStackView.swift
@@ -1,5 +1,5 @@
 // ScrollableStackView.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 

--- a/src/UI/Sources/UI/WindowCoordinator.swift
+++ b/src/UI/Sources/UI/WindowCoordinator.swift
@@ -1,5 +1,5 @@
 // WindowCoordinator.swift
-// Copyright (c) 2020 Dylan Gattey
+// Copyright (c) 2022 Dylan Gattey
 
 import AppKit
 


### PR DESCRIPTION
Deletes the unused vars + updates the copyright to 2022